### PR TITLE
Bug fixes and API client experience enhancements

### DIFF
--- a/src/Samples/SlimCluster.Samples.Service/Controllers/CounterController.cs
+++ b/src/Samples/SlimCluster.Samples.Service/Controllers/CounterController.cs
@@ -27,8 +27,18 @@ public class CounterController : ControllerBase
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
     public async Task<int?> Increment(CancellationToken cancellationToken)
     {
-        var result = await _clientRequestHandler.OnClientRequest(new IncrementCounterCommand(), cancellationToken);
-        return (int?)result;
+        int? result = null;
+        try
+        {
+            result = (int?)await _clientRequestHandler.OnClientRequest(new IncrementCounterCommand(), cancellationToken);
+            result ??= -1;
+        }
+        catch (Exception ex) 
+        {
+            throw;
+        }
+
+        return result;
     }
 
     [HttpPost("[action]")]
@@ -45,5 +55,21 @@ public class CounterController : ControllerBase
     {
         var result = await _clientRequestHandler.OnClientRequest(new ResetCounterCommand(), cancellationToken);
         return (int?)result;
+    }
+
+    [HttpPost("[action]")]
+    [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
+    public async Task<bool?> LockRequest([FromBody] LockRequestCommand command, CancellationToken cancellationToken)
+    {
+        var result = await _clientRequestHandler.OnClientRequest(command, cancellationToken);
+        return (bool?)result;
+    }
+
+    [HttpPost("[action]")]
+    [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
+    public async Task<bool?> LockRelease([FromBody] LockReleaseCommand command, CancellationToken cancellationToken)
+    {
+        var result = await _clientRequestHandler.OnClientRequest(command, cancellationToken);
+        return (bool?)result;
     }
 }

--- a/src/Samples/SlimCluster.Samples.Service/Kube-ApplySample.ps1
+++ b/src/Samples/SlimCluster.Samples.Service/Kube-ApplySample.ps1
@@ -1,3 +1,5 @@
 # run with tty console, interactive mode, and remove container after program ends
 kubectl apply -f service.yaml
+kubectl apply -f configmap.yaml
+kubectl apply -f persistent-volume-claim.yaml
 kubectl apply -f deployment.yaml

--- a/src/Samples/SlimCluster.Samples.Service/Kube-DeleteSample.ps1
+++ b/src/Samples/SlimCluster.Samples.Service/Kube-DeleteSample.ps1
@@ -1,2 +1,4 @@
 kubectl delete -f deployment.yaml
 #kubectl delete -f service.yaml
+#kubectl delete -f persistent-volume-claim.yaml
+#kubectl delete -f persistent-volume.yaml

--- a/src/Samples/SlimCluster.Samples.Service/Program.cs
+++ b/src/Samples/SlimCluster.Samples.Service/Program.cs
@@ -51,10 +51,10 @@ builder.Services.AddSlimCluster(cfg =>
         opts.NodeCount = 3;
 
         // Use custom values or remove and use defaults
-        opts.LeaderTimeout = TimeSpan.FromSeconds(5);
-        opts.LeaderPingInterval = TimeSpan.FromSeconds(2);
-        opts.ElectionTimeoutMin = TimeSpan.FromSeconds(3);
-        opts.ElectionTimeoutMax = TimeSpan.FromSeconds(6);
+        opts.LeaderTimeout = TimeSpan.FromSeconds(5f/8);
+        opts.LeaderPingInterval = TimeSpan.FromSeconds(2f/8);
+        opts.ElectionTimeoutMin = TimeSpan.FromSeconds(3f/8);
+        opts.ElectionTimeoutMax = TimeSpan.FromSeconds(6f/8);
         // Can set a different log serializer, by default ISerializer is used (in our setup its JSON)
         // opts.LogSerializerType = typeof(JsonSerializer);
     });

--- a/src/Samples/SlimCluster.Samples.Service/State/Logs/CommandSerializationTypeAliasProvider.cs
+++ b/src/Samples/SlimCluster.Samples.Service/State/Logs/CommandSerializationTypeAliasProvider.cs
@@ -1,5 +1,6 @@
 ﻿namespace SlimCluster.Samples.ConsoleApp.State.Logs;
 
+using SlimCluster.Consensus.Raft;
 using SlimCluster.Serialization;
 
 internal class CommandSerializationTypeAliasProvider : ISerializationTypeAliasProvider
@@ -9,5 +10,7 @@ internal class CommandSerializationTypeAliasProvider : ISerializationTypeAliasPr
         ["dec"] = typeof(DecrementCounterCommand),
         ["inc"] = typeof(IncrementCounterCommand),
         ["rst"] = typeof(ResetCounterCommand),
+        ["lrq"] = typeof(LockRequestCommand),
+        ["lrl"] = typeof(LockReleaseCommand),
     };
 }

--- a/src/Samples/SlimCluster.Samples.Service/State/StateMachine/CounterStateMachine.cs
+++ b/src/Samples/SlimCluster.Samples.Service/State/StateMachine/CounterStateMachine.cs
@@ -1,12 +1,15 @@
 ﻿namespace SlimCluster.Samples.ConsoleApp.State.StateMachine;
 
 using SlimCluster.Consensus.Raft;
+using SlimCluster.Persistence;
 using SlimCluster.Samples.ConsoleApp.State.Logs;
+
+using static SlimCluster.Samples.ConsoleApp.State.StateMachine.CounterStateMachine;
 
 /// <summary>
 /// Counter state machine that processes counter commands. Everything is stored in memory.
 /// </summary>
-public class CounterStateMachine : IStateMachine, ICounterState
+public class CounterStateMachine : IStateMachine, ICounterState, IDurableComponent
 {
     private int _index = 0;
     private int _counter = 0;
@@ -18,7 +21,15 @@ public class CounterStateMachine : IStateMachine, ICounterState
     /// </summary>
     public int Counter => _counter;
 
-    public Task<object?> Apply(object command, int index)
+    public List<LockRequestCommand> _locks = new();
+
+    //public CounterStateMachine(LoggerFactory loggerFactory)
+    //{
+    //    _logger=loggerFactory.CreateLogger<CounterStateMachine>();
+    //}
+    //private ILogger<CounterStateMachine> _logger;  
+
+    public async Task<object?> Apply(object command, int index)
     {
         // Note: This is thread safe - there is ever going to be only one task at a time calling Apply
 
@@ -27,17 +38,57 @@ public class CounterStateMachine : IStateMachine, ICounterState
             throw new InvalidOperationException($"The State Machine can only apply next command at index ${_index + 1}");
         }
 
-        int? result = command switch
+        //await Task.Delay(20000);
+
+        object? result = null;
+
+        switch (command)
         {
-            IncrementCounterCommand => ++_counter,
-            DecrementCounterCommand => --_counter,
-            ResetCounterCommand => _counter = 0,
-            _ => throw new NotImplementedException($"The command type ${command?.GetType().Name} is not supported")
-        };
+            case LockRequestCommand lockRequest:
+
+                result = lockRequest.Result;
+
+                if(lockRequest.Result)
+                {
+                    var existing = _locks.SingleOrDefault(lock_ => lock_.Name.Equals(lockRequest.Name, StringComparison.CurrentCultureIgnoreCase)); 
+                    if (existing is null)
+                    {
+                        _locks.Add(lockRequest);
+                    }
+                    // Change owner
+                    else if(!existing.Owner.Equals(lockRequest.Owner, StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        existing.Owner = lockRequest.Owner;
+                    }
+                }
+                break;
+            case LockReleaseCommand lockRelease:
+
+                result = lockRelease.Result;
+                if (lockRelease.Result)
+                {
+                    var existing = _locks.SingleOrDefault(lock_ => lock_.Name.Equals(lockRelease.Name, StringComparison.CurrentCultureIgnoreCase) && lock_.Owner.Equals(lockRelease.Owner, StringComparison.CurrentCultureIgnoreCase));
+                    if (existing is not null)
+                    {
+                        _locks.Remove(existing);
+                    }
+                }
+                break;
+            default:
+
+                result = command switch
+                {
+                    IncrementCounterCommand => ++_counter,
+                    DecrementCounterCommand => --_counter,
+                    ResetCounterCommand => _counter = 0,
+                    _ => throw new NotImplementedException($"The command type ${command?.GetType().Name} is not supported")
+                };
+                break;
+        }
 
         _index = index;
 
-        return Task.FromResult<object?>(result);
+        return result;
     }
 
     // For now we don't support snapshotting
@@ -45,4 +96,12 @@ public class CounterStateMachine : IStateMachine, ICounterState
 
     // For now we don't support snapshotting
     public Task Snapshot() => throw new NotImplementedException();
+
+    public void OnStatePersist(IStateWriter state)
+    {
+        state.Set("counter", _counter);
+        state.Set("locks", _locks);
+    }
+
+    public void OnStateRestore(IStateReader state) => throw new NotImplementedException();
 }

--- a/src/Samples/SlimCluster.Samples.Service/configmap.yaml
+++ b/src/Samples/SlimCluster.Samples.Service/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+data:
+  config-file.txt: |
+    key1=value1
+    key2=value2

--- a/src/Samples/SlimCluster.Samples.Service/deployment.yaml
+++ b/src/Samples/SlimCluster.Samples.Service/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: sc-service
   labels:
@@ -25,3 +25,34 @@ spec:
         env:
         - name: ASPNETCORE_URLS
           value: "http://+:8080"
+        volumeMounts:
+        # ConfigMap
+        - mountPath: /etc/config # path in pod in which ConfigMap's config-file.txt will be written
+          name: config-volume
+        # Ephemeral not supported during dev
+        # - mountPath: /etc/data # path in pod in which the emphemeral volume is mounted
+        #  name: my-ephemeral-volume
+        - mountPath: /data/pvc
+          name: pvc-volume
+        - mountPath: /data
+          name: my-volume
+      volumes:
+      - name: config-volume
+        configMap:
+          name: my-config
+      # - name: my-ephemeral-volume
+        # csi:
+        # driver: my-csi-driver
+        # volumeAttributes:
+        #   size: "1Gi"
+      - name: pvc-volume
+        persistentVolumeClaim:
+          claimName: local-pvc
+  volumeClaimTemplates:
+  - metadata:
+      name: my-volume
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi

--- a/src/Samples/SlimCluster.Samples.Service/persistent-volume-claim.yaml
+++ b/src/Samples/SlimCluster.Samples.Service/persistent-volume-claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/src/Samples/SlimCluster.Samples.Service/service.yaml
+++ b/src/Samples/SlimCluster.Samples.Service/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     run: sc-service
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
   - port: 8080
     protocol: TCP

--- a/src/SlimCluster.AspNetCore/Configuration/ClusterConfigurationExtensions.cs
+++ b/src/SlimCluster.AspNetCore/Configuration/ClusterConfigurationExtensions.cs
@@ -10,12 +10,13 @@ public static class ClusterConfigurationExtensions
     {
         cfg.PostConfigurationActions.Add(services =>
         {
+            // This client is used for followers to redirect requests to primaries.
             services.AddHttpClient<RequestDelegatingClient>(client => {
                 // If the leader fails then followers will attempt to contact it and it needs to fail quickly because the leader's IP may change to
                 // a new node and therefore the target IP for this client call may no longer be valid.
                 // TODO: Should be an should be an option.
                 // ElectionTimeoutMax = 6?
-                client.Timeout = TimeSpan.FromSeconds(6);
+                client.Timeout = TimeSpan.FromSeconds(60);
             });
 
             services.Configure(options);

--- a/src/SlimCluster.AspNetCore/Configuration/ClusterConfigurationExtensions.cs
+++ b/src/SlimCluster.AspNetCore/Configuration/ClusterConfigurationExtensions.cs
@@ -10,7 +10,13 @@ public static class ClusterConfigurationExtensions
     {
         cfg.PostConfigurationActions.Add(services =>
         {
-            services.AddHttpClient<RequestDelegatingClient>();
+            services.AddHttpClient<RequestDelegatingClient>(client => {
+                // If the leader fails then followers will attempt to contact it and it needs to fail quickly because the leader's IP may change to
+                // a new node and therefore the target IP for this client call may no longer be valid.
+                // TODO: Should be an should be an option.
+                // ElectionTimeoutMax = 6?
+                client.Timeout = TimeSpan.FromSeconds(6);
+            });
 
             services.Configure(options);
         });

--- a/src/SlimCluster.AspNetCore/Middleware/ClusterLeaderRequestDelegatingMiddleware.cs
+++ b/src/SlimCluster.AspNetCore/Middleware/ClusterLeaderRequestDelegatingMiddleware.cs
@@ -1,9 +1,9 @@
 ﻿namespace SlimCluster.AspNetCore;
 
+using System.Net.Mime;
 using System.Text.Json;
 
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using SlimCluster.Consensus.Raft;
@@ -52,10 +52,11 @@ public class ClusterLeaderRequestDelegatingMiddleware
             if(ex is ClusterException)
             {
                 context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                context.Response.ContentType = "application/json";
-                string payload = JsonSerializer.Serialize(new { ex.Message, ExceptionType = ex.GetType().Name });
+                context.Response.ContentType = MediaTypeNames.Application.Json;
+                var payload = JsonSerializer.Serialize(new { ex.Message, ExceptionType = ex.GetType().Name });
                 context.Response.ContentLength = payload.Length;
                 await context.Response.WriteAsync(payload);
+                return;
             }
             throw;
         }

--- a/src/SlimCluster.Consensus.Raft/Configuration/RaftConsensusOptions.cs
+++ b/src/SlimCluster.Consensus.Raft/Configuration/RaftConsensusOptions.cs
@@ -16,12 +16,13 @@ public class RaftConsensusOptions
     /// <summary>
     /// Timeout after which a leader is considered dead (unless ApppendEntriesRequest arrives).
     /// </summary>
-    public TimeSpan LeaderTimeout { get; set; } = TimeSpan.FromSeconds(2);
+    // Not needed
+    //public TimeSpan LeaderTimeout { get; set; } = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Time after which an empty AppendEntriesRequest must be sent to prevent Leader timout from happening.
     /// </summary>
-    public TimeSpan LeaderPingInterval { get; set; } = TimeSpan.FromMilliseconds(250);
+    public TimeSpan HeartbeatInterval { get; set; } = TimeSpan.FromMilliseconds(250);
 
     /// <summary>
     /// Defines the target cluster size. It is used to calculate majority of nodes.
@@ -37,4 +38,6 @@ public class RaftConsensusOptions
     /// The timeout for a leader to process the request.
     /// </summary>
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    public TimeSpan FifoLockTimeout { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/src/SlimCluster.Consensus.Raft/FifoLock.cs
+++ b/src/SlimCluster.Consensus.Raft/FifoLock.cs
@@ -1,0 +1,54 @@
+﻿namespace SlimCluster.Consensus.Raft;
+
+public class FifoLock
+{
+    private readonly Queue<(ManualResetEventSlim ResetEvent, bool IsTimeout)> _queue = new();
+    private readonly object _lock = new();
+
+    //private readonly ILogger _logger;
+    private readonly TimeSpan _timeoutPeriod;
+
+    public FifoLock(TimeSpan timeoutPeriod) //ILogger logger)
+    {
+        _timeoutPeriod = timeoutPeriod;
+        //_logger = logger;
+    }
+
+    public bool Enter()
+    {
+        (ManualResetEventSlim ResetEvent, bool IsTimeout) signal = (new(false), false);
+        lock (_lock)
+        {
+            _queue.Enqueue(signal);
+
+            if (_queue.Count == 1)
+            {
+                signal.ResetEvent.Set();
+            }
+        }
+
+        var index = Task.WaitAny(Task.Run(signal.ResetEvent.Wait), Task.Delay(_timeoutPeriod));
+        
+        signal.IsTimeout = (index == 1);
+
+        return index == 0;
+    }
+
+    public void Exit()
+    {
+        lock (_lock)
+        {
+            var signal = _queue.Dequeue();
+
+            if (_queue.Count > 0)
+            {
+                if (signal.IsTimeout)
+                {
+                    Exit();
+                }
+                _queue.Peek().ResetEvent.Set();
+            }
+            signal.ResetEvent.Dispose();
+        }
+    }
+}

--- a/src/SlimCluster.Consensus.Raft/LockReleaseCommand.cs
+++ b/src/SlimCluster.Consensus.Raft/LockReleaseCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace SlimCluster.Consensus.Raft;
+
+public record LockReleaseCommand() //: AbstractCommand
+{
+    public string Name { get; set; }
+    public string Owner { get; set; }
+    public bool Result { get; set; }
+}

--- a/src/SlimCluster.Consensus.Raft/LockRequestCommand.cs
+++ b/src/SlimCluster.Consensus.Raft/LockRequestCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace SlimCluster.Consensus.Raft;
+
+public record LockRequestCommand() //: AbstractCommand
+{
+    public string Name { get; set; }
+    public string Owner { get; set; }
+    public bool Result { get; set; }
+}

--- a/src/SlimCluster.Consensus.Raft/RaftFollowerState.cs
+++ b/src/SlimCluster.Consensus.Raft/RaftFollowerState.cs
@@ -2,7 +2,7 @@
 
 public class RaftFollowerState
 {
-    private readonly RaftConsensusOptions _options;
+    private readonly TimeSpan _leaderTimeout;
     private readonly ITime _time;
     private readonly ILogger<RaftFollowerState> _logger;
 
@@ -12,10 +12,10 @@ public class RaftFollowerState
 
     public INode? Leader { get; protected set; }
 
-    public RaftFollowerState(ILogger<RaftFollowerState> logger, RaftConsensusOptions options, ITime time, int term, INode? leaderNode)
+    public RaftFollowerState(ILogger<RaftFollowerState> logger, TimeSpan leaderTimeout, ITime time, int term, INode? leaderNode)
     {
         _logger = logger;
-        _options = options;
+        _leaderTimeout = leaderTimeout;
         _time = time;
         _term = term;
         Leader = leaderNode;
@@ -24,7 +24,7 @@ public class RaftFollowerState
 
     public void OnLeaderMessage(INode? leaderNode)
     {
-        LeaderTimeout = _time.Now.Add(_options.LeaderTimeout);
+        LeaderTimeout = _time.Now.Add(_leaderTimeout);
         if (Leader != leaderNode)
         {
             Leader = leaderNode;

--- a/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
+++ b/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
@@ -111,7 +111,7 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
         // ToDo: Remove lost nodes from ReplicationStateByNode (after some idle time)
 
         // ToDo: Perhaps run in a separate task loop
-        idleRun &= await TryApplyLogs().ConfigureAwait(false);
+        idleRun |= await TryApplyLogs().ConfigureAwait(false);
 
         // idle run
         return idleRun;

--- a/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
+++ b/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
@@ -125,7 +125,7 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
 
         var commitedIndex = _logRepository.CommitedIndex;
         var highestReplicatedIndex = FindMajorityReplicatedIndex();
-        if (highestReplicatedIndex > commitedIndex)
+        if (highestReplicatedIndex >= commitedIndex)
         {
             await ApplyLogs(commitedIndex, highestReplicatedIndex).ConfigureAwait(false);
             idleRun = false;
@@ -157,15 +157,23 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
         }
     }
 
-    private int FindMajorityReplicatedIndex()
+    private int GetMajorityCountMinusOne()
     {
         var majorityCount = _options.NodeCount / 2;
+           
+        return majorityCount;
+    }
+
+    private int FindMajorityReplicatedIndex()
+    {
+        var majorityCount = GetMajorityCountMinusOne();
 
         // ToDo: Do not take into acount inactive members
         var orderedMatchIndexes = ReplicationStateByNode.Values.Select(x => x.MatchIndex).OrderByDescending(x => x).ToList();
 
         var majorityMatchIndex = orderedMatchIndexes.FirstOrDefault(matchIndex =>
         {
+            // This considers members that have left.
             return orderedMatchIndexes.Count(x => x >= matchIndex) + _options.NodeCount - _clusterMembership.Members.Count > majorityCount;
         });
 
@@ -257,6 +265,12 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
     public async Task<object?> OnClientRequest(object command, CancellationToken token)
     {
         using var _ = _logger.BeginScope("Command {Command} processing", command.GetType().Name);
+
+        var majorityCount = GetMajorityCountMinusOne();
+        if (_clusterMembership.Members.Count <= majorityCount)
+        {
+            throw new ClusterException("This node is not a member of a cluster having a quorum. While trying again may result in routing to a node having a quorum, there is no guarantee this will occur. To resolve, increase the number of nodes running in the cluster or address a possible network fragmentation.");
+        }
 
         // Append log to local node (must be thread-safe)
         var log = _logSerializer.Serialize(command);

--- a/src/SlimCluster.Consensus.Raft/StateMachine/StateMachineExtensions.cs
+++ b/src/SlimCluster.Consensus.Raft/StateMachine/StateMachineExtensions.cs
@@ -10,6 +10,7 @@ public static class StateMachineExtensions
         logger.LogTrace("Deserializing log at index {LogIndex}", logIndex);
         var command = logSerializer.Deserialize(logEntry);
         logger.LogDebug("Applying log at index {LogIndex}", logIndex);
+        logger.LogInformation("Applying command {command}", command);
         var commandResult = await stateMachine.Apply(command, logIndex).ConfigureAwait(false);
         logger.LogDebug("Commit log at index {LogIndex}", logIndex);
         await logRepository.Commit(logIndex).ConfigureAwait(false);

--- a/src/SlimCluster.Host/Common/TaskLoop.cs
+++ b/src/SlimCluster.Host/Common/TaskLoop.cs
@@ -1,9 +1,11 @@
 ﻿namespace SlimCluster.Host.Common;
 
+using Microsoft.Extensions.Options;
+
 public abstract class TaskLoop
 {
     private readonly ILogger _logger;
-    private readonly TimeSpan _idleLoopDelay;
+    private readonly ClusterOptions _options;
 
     private CancellationTokenSource? _loopCts;
     private Task? _loopTask;
@@ -13,16 +15,12 @@ public abstract class TaskLoop
 
     public bool IsStarted => _isStarted;
 
-    protected TaskLoop(ILogger logger, TimeSpan idleLoopDelay)
+    protected TaskLoop(ILogger logger, ClusterOptions options)
     {
         _logger = logger;
-        _idleLoopDelay = idleLoopDelay;
+        _options = options;
     }
 
-    protected TaskLoop(ILogger logger)
-        : this(logger, TimeSpan.FromMilliseconds(50))
-    {
-    }
     public async Task Start()
 
     {
@@ -95,7 +93,7 @@ public abstract class TaskLoop
                     var idleRun = await OnLoopRun(_loopCts.Token).ConfigureAwait(false);
                     if (idleRun)
                     {
-                        await Task.Delay(_idleLoopDelay).ConfigureAwait(false);
+                        await Task.Delay(_options.IdleLoopDelay).ConfigureAwait(false);
                     }
                 }
                 catch (Exception e)

--- a/src/SlimCluster.Host/Configuration/ClusterOptions.cs
+++ b/src/SlimCluster.Host/Configuration/ClusterOptions.cs
@@ -11,4 +11,7 @@ public class ClusterOptions
     /// The unique ID representing this node instance.
     /// </summary>
     public string NodeId { get; set; } = Guid.NewGuid().ToString();
+
+
+    public TimeSpan IdleLoopDelay { get; set; } = TimeSpan.FromMilliseconds(50);
 }

--- a/src/SlimCluster.Membership.Swim/SwimClusterMembership.cs
+++ b/src/SlimCluster.Membership.Swim/SwimClusterMembership.cs
@@ -72,7 +72,7 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
         IOptions<ClusterOptions> clusterOptions,
         ITime time,
         IMessageSender messageSender)
-        : base(loggerFactory.CreateLogger<SwimClusterMembership>())
+        : base(loggerFactory.CreateLogger<SwimClusterMembership>(), clusterOptions.Value)
     {
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<SwimClusterMembership>();

--- a/src/SlimCluster.Persistence.LocalFile/ClusterConfigurationExtensions.cs
+++ b/src/SlimCluster.Persistence.LocalFile/ClusterConfigurationExtensions.cs
@@ -13,6 +13,7 @@ public static class ClusterConfigurationExtensions
     {
         cfg.PostConfigurationActions.Add(services =>
         {
+            Console.WriteLine($"AddPersistenceUsingLocalFile file path: {filePath}");
             services.TryAddTransient(svp => new LocalJsonFileClusterPersistenceService(svp.GetServices<IDurableComponent>(), filePath, formatting));
             services.TryAddTransient<IClusterPersistenceService>(svp => svp.GetRequiredService<LocalJsonFileClusterPersistenceService>());
         });

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/AbstractRaftIntegrationTest.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/AbstractRaftIntegrationTest.cs
@@ -9,6 +9,7 @@ public abstract class AbstractRaftIntegrationTest
 {
     protected readonly IFixture _fixture;
     protected readonly RaftConsensusOptions _options;
+    protected readonly ClusterOptions _clusterOptions;
     protected readonly Mock<IServiceProvider> _serviceProviderMock;
     protected readonly Mock<IStateMachine> _stateMachineMock;
     protected readonly Mock<IClusterMembership> _clusterMembershipMock;
@@ -35,6 +36,8 @@ public abstract class AbstractRaftIntegrationTest
         {
             NodeCount = 3
         };
+
+        _clusterOptions = new();
 
         static Node GetNode(int i) => new($"Node-{i:00}", $"192.168.1.{i}", 6200);
 

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderStateTests.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderStateTests.cs
@@ -18,8 +18,10 @@ public class RaftLeaderStateTests : AbstractRaftIntegrationTest, IAsyncLifetime
 
         _subject = new RaftLeaderState(
             XUnitLogger.CreateLogger<RaftLeaderState>(testOutputHelper),
+            _serviceProviderMock.Object,
             _term,
             _options,
+            _clusterOptions,
             _clusterMembershipMock.Object,
             _messageSenderMock.Object,
             _logRepositoryMock.Object,
@@ -28,7 +30,7 @@ public class RaftLeaderStateTests : AbstractRaftIntegrationTest, IAsyncLifetime
             new Time(),
             _onNewerTermDiscovered.Object);
 
-        _options.LeaderPingInterval = TimeSpan.FromSeconds(0.5);
+        _options.HeartbeatInterval = TimeSpan.FromSeconds(0.5);
     }
 
     public Task DisposeAsync() => _subject.Stop();
@@ -87,21 +89,21 @@ public class RaftLeaderStateTests : AbstractRaftIntegrationTest, IAsyncLifetime
             .Verify(x => x.SendRequest(
                 It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 0 && r.PrevLogTerm == 0 && r.Entries == null),
                 It.IsAny<IAddress>(),
-                _options.LeaderPingInterval),
+                _options.HeartbeatInterval),
                 Times.AtLeast(_otherMembers.Count));
 
         _messageSenderMock
             .Verify(x => x.SendRequest(
                 It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 0 && r.PrevLogTerm == 0 && r.Entries != null && r.Entries.Count == 1 && r.Entries.First().Entry == commandPayload),
                 It.IsAny<IAddress>(),
-                _options.LeaderPingInterval),
+                _options.HeartbeatInterval),
                 Times.Exactly(_otherMembers.Count));
 
         _messageSenderMock
             .Verify(x => x.SendRequest(
                 It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 1 && r.PrevLogTerm == 1 && r.Entries == null),
                 It.IsAny<IAddress>(),
-                _options.LeaderPingInterval),
+                _options.HeartbeatInterval),
                 Times.AtLeast(_otherMembers.Count));
 
         _messageSenderMock

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/RaftNodeTests.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/RaftNodeTests.cs
@@ -7,8 +7,8 @@ using SlimCluster.Transport.Ip;
 
 public class RaftNodeProxy : RaftNode
 {
-    public RaftNodeProxy(ILoggerFactory loggerFactory, IServiceProvider serviceProvider, IClusterMembership clusterMembership, ITime time, ILogRepository logRepository, IMessageSender messageSender, IStateMachine stateMachine, IOptions<RaftConsensusOptions> options)
-        : base(loggerFactory, serviceProvider, clusterMembership, time, logRepository, messageSender, stateMachine, options)
+    public RaftNodeProxy(ILoggerFactory loggerFactory, IServiceProvider serviceProvider, IClusterMembership clusterMembership, ITime time, ILogRepository logRepository, IMessageSender messageSender, IStateMachine stateMachine, IOptions<RaftConsensusOptions> options, IOptions<ClusterOptions> clusterOptions)
+        : base(loggerFactory, serviceProvider, clusterMembership, time, logRepository, messageSender, stateMachine, options, clusterOptions)
     {
     }
 
@@ -35,7 +35,7 @@ public class RaftNodeTests : AbstractRaftIntegrationTest, IAsyncLifetime
 
     public RaftNodeTests()
     {
-        _subject = new RaftNodeProxy(NullLoggerFactory.Instance, _serviceProviderMock.Object, _clusterMembershipMock.Object, _timeMock.Object, _logRepositoryMock.Object, _messageSenderMock.Object, _stateMachineMock.Object, Options.Create(_options));
+        _subject = new RaftNodeProxy(NullLoggerFactory.Instance, _serviceProviderMock.Object, _clusterMembershipMock.Object, _timeMock.Object, _logRepositoryMock.Object, _messageSenderMock.Object, _stateMachineMock.Object, Options.Create(_options), Options.Create(_clusterOptions));
     }
 
     public Task InitializeAsync() => Task.CompletedTask;
@@ -170,7 +170,7 @@ public class RaftNodeTests : AbstractRaftIntegrationTest, IAsyncLifetime
                     x => x.SendRequest(
                         It.Is<AppendEntriesRequest>(r => r.Term == candidateTerm && r.LeaderId == _selfMember.Node.Id),
                         member.Node.Address,
-                        _options.LeaderPingInterval),
+                        _options.HeartbeatInterval),
                     Times.Once);
             }
         }

--- a/src/Tests/SlimCluster.Test/TaskLoopTests.cs
+++ b/src/Tests/SlimCluster.Test/TaskLoopTests.cs
@@ -8,7 +8,7 @@ public class TaskLoopTests
 
     public TaskLoopTests()
     {
-        subjectMock = new Mock<TaskLoop>(NullLogger.Instance) { CallBase = true };
+        subjectMock = new Mock<TaskLoop>(NullLogger.Instance, new ClusterOptions()) { CallBase = true };
     }
 
     [Fact]

--- a/src/Tests/SlimCluster.Transport.Ip.Tests/IPMessageEndpointTests.cs
+++ b/src/Tests/SlimCluster.Transport.Ip.Tests/IPMessageEndpointTests.cs
@@ -3,6 +3,7 @@
 public class IPMessageEndpointTests
 {
     private readonly IpTransportOptions _options;
+    private readonly ClusterOptions _clusterOptions;
     private readonly Mock<ISerializer> _serializerMock;
     private readonly Mock<IMessageSendingHandler> _messageSendingHandlerMock;
     private readonly Mock<IMessageArrivedHandler> _messageArrivedHandlerMock;
@@ -11,6 +12,7 @@ public class IPMessageEndpointTests
     public IPMessageEndpointTests()
     {
         _options = new IpTransportOptions();
+        _clusterOptions = new ClusterOptions();
         _serializerMock = new Mock<ISerializer>();
         _messageSendingHandlerMock = new Mock<IMessageSendingHandler>();
         _messageArrivedHandlerMock = new Mock<IMessageArrivedHandler>();
@@ -45,6 +47,7 @@ public class IPMessageEndpointTests
         await using var subject = new IPMessageEndpoint(
             NullLogger<IPMessageEndpoint>.Instance,
             Options.Create(_options),
+            Options.Create(_clusterOptions),
             _serializerMock.Object,
             new[] { _messageSendingHandlerMock.Object },
             new[] { _messageArrivedHandlerMock.Object },


### PR DESCRIPTION
**Bugs:**

1) Implemented idleRun fix so that idle will occur in OnRunLoop
2) FindMajorityReplicatedIndex now calculates the majority match index when the cluster is degraded.  Previously, when degraded the ReplicationStateByNode count was lower than needed to result in the necessary majority match index value.

**API Client Experience:**

In cases were nodes fail and in cases where nodes are recreated by Kubernetes, calls to Increment might return null and HTTP status 204.  This may occur because of one of four types of exceptions that may be thrown when requests are being received during state synchronization.  The below changes were made to attempt to notify the client of the reason the API call failed so that the client can 1) understand the issue and 2) handle the issue.

1) ClusterLeaderRequestDelegatingMiddleware returns a 503 and the ClusterException message.
2) RaftLeaderState and RequestDelegatingClient convert certain exceptions to a ClusterException that will propagate back to the client.