### PR TITLE
Docs, tests, fixes, NuGet spec improvements

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,6 +10,9 @@
   - [Local File Persistence](#local-file-persistence)
 - [Cluster Membership](#cluster-membership)
   - [SWIM Membership](#swim-membership)
+    - [SWIM Configuration Parameters](#swim-configuration-parameters)
+    - [Member Statuses](#member-statuses)
+    - [Observing Membership Changes](#observing-membership-changes)
   - [Static Membership](#static-membership)
 - [Cluster Consensus](#cluster-consensus)
   - [Raft Consensus](#raft-consensus)
@@ -19,6 +22,9 @@
     - [State Machine](#state-machine)
     - [Configuration Parameters](#configuration-parameters)
   - [Leader Request Delegation ASP.NET Core Middleware](#leader-request-delegation-aspnet-core-middleware)
+    - [Setup](#setup)
+    - [Behaviour](#behaviour)
+    - [`DelegateRequestToLeader` predicate](#delegaterequesttoleader-predicate)
 
 # About
 
@@ -128,7 +134,7 @@ cfg.AddJsonSerialization();
 
 Package: [SlimCluster.Persistence](https://www.nuget.org/packages/SlimCluster.Persistence)
 
-The Node (service instance) needs to persist the minimal cluster state in between instance restarts (or crushes) to quickly catch up with the other Nodes in the cluster.
+The Node (service instance) needs to persist the minimal cluster state in between instance restarts (or crashes) to quickly catch up with the other Nodes in the cluster.
 Depending on the plugins and configuration used, such state might include:
 
 - Last known member list
@@ -173,7 +179,67 @@ SlimCluster has the [SWIM membership](#swim-membership) algorithm implemented as
 
 Package: [SlimCluster.Membership.Swim](https://www.nuget.org/packages/SlimCluster.Membership.Swim)
 
-ToDo
+SWIM (Scalable Weakly-consistent Infection-style Membership) is a gossip-based protocol for detecting node failures and maintaining the cluster member list without a central coordinator.
+Each node periodically probes a random peer (Ping). If no Ack is received within the timeout, it sends indirect probes via a subgroup of other members (PingReq).
+Membership change events (joins, departures, failures) are piggybacked onto these protocol messages and eventually propagate to every node.
+
+To add the SWIM plugin register it:
+
+```cs
+cfg.AddSwimMembership(opts =>
+{
+    opts.MembershipEventPiggybackCount = 2;
+});
+```
+
+### SWIM Configuration Parameters
+
+All properties are on `SwimClusterMembershipOptions`:
+
+| Property                        | Default | Description                                                                                         |
+| ------------------------------- | ------- | --------------------------------------------------------------------------------------------------- |
+| `ProtocolPeriod`                | `5s`    | How often the failure detection cycle (T') runs. Should be at least 3× the network round-trip time. |
+| `FailureDetectionSubgroupSize`  | `3`     | Number of nodes (k) used for indirect probing when a direct Ping is unanswered.                     |
+| `PingAckTimeout`                | `1.25s` | How long to wait for an Ack before treating the probe as failed.                                    |
+| `MembershipEventBufferCount`    | `20`    | Size of the per-node event buffer used for gossip propagation.                                      |
+| `MembershipEventPiggybackCount` | `3`     | How many buffered events are piggybacked on each Ping/Ack message.                                  |
+
+### Member Statuses
+
+SWIM nodes transition through the following statuses:
+
+| Status       | `IsActive` | Meaning                                                                 |
+| ------------ | ---------- | ----------------------------------------------------------------------- |
+| `Active`     | ✓          | Node is responding normally.                                            |
+| `Suspicious` | ✗          | Direct probe failed; indirect probes are in-flight.                     |
+| `Confirming` | ✓          | Node was suspected but has since replied; waiting for confirmation.     |
+| `Faulted`    | ✗          | No probe succeeded within the protocol period; node is considered dead. |
+
+### Observing Membership Changes
+
+Inject `IClusterMembership` to react to member events:
+
+```cs
+public class MyService
+{
+    public MyService(IClusterMembership membership)
+    {
+        membership.MemberJoined += (_, e) =>
+            Console.WriteLine($"Node {e.Node.Id} joined");
+
+        membership.MemberLeft += (_, e) =>
+            Console.WriteLine($"Node {e.Node.Id} left or faulted");
+
+        membership.MemberStatusChanged += (_, e) =>
+        {
+            if (e.Node.Status == SwimMemberStatus.Suspicious)
+                Console.WriteLine($"Node {e.Node.Id} is suspicious");
+        };
+    }
+}
+```
+
+The `IClusterMembership.Members` and `OtherMembers` collections give a consistent snapshot of the current live members at any point in time.
 
 ## Static Membership
 
@@ -184,7 +250,7 @@ If the members of the cluster are known then you do not need to run a membership
 - The node names (or IP address) are known and fixed,
 - Perhaps there is an external framework (or middleware) that tracks the node names (or IP address).
 
-ToDo:
+In this case you can register the known members directly in the MSDI container as `IMember` instances and skip the dynamic membership plugin entirely. This is useful in local development, integration tests, or environments where node addresses are stable (e.g. Kubernetes StatefulSets with predictable DNS names).
 
 # Cluster Consensus
 
@@ -197,7 +263,7 @@ Consensus allows to coordinate the nodes that form the cluster. It helps to mana
 Package: [SlimCluster.Consensus.Raft](https://www.nuget.org/packages/SlimCluster.Consensus.Raft)
 
 Raft consensus algorithm is one of the newer algorithms that has become popular due to its simplicity and flexibility.
-The [Raft paper](https://raft.github.io/raft.pdf) is an excelent source to undersand more details about the algorithm, and the parameters that can be fine tuned in SlimCluster.
+The [Raft paper](https://raft.github.io/raft.pdf) is an excellent source to understand more details about the algorithm, and the parameters that can be fine tuned in SlimCluster.
 
 At a high level the Raft consensus is:
 
@@ -279,7 +345,7 @@ The state machine is being evaluated on every node on the cluster (not only the 
 All node state machines eventually end up in the same state across leader and follower nodes.
 
 Leader is the one that decides up to what log index should be applied against the state machine.
-A log at index `N` is applied onto the state machine if the log at index `N` (and all before it) hve been replicated by the leader to a majority of nodes in the cluster.
+A log at index `N` is applied onto the state machine if the log at index `N` (and all before it) have been replicated by the leader to a majority of nodes in the cluster.
 
 The state machine represents your custom domain problem that, and works with the custom logs (commands) that are relevant for the state machine.
 For example if we are building a distributed counter, then the state machine is able to handle IncrementCounterCommand, DecrementCounterCommand, etc. The evaluation of each command, causes the counter increments, decrements.
@@ -348,13 +414,49 @@ cfg.AddRaftConsensus(opts =>
 ```
 
 - `NodeCount` sets the expected node count of the cluster. This is needed to be able to calculate the majority of nodes.
-- `LeaderTimeout` the time after which the leader is considered crashed/gone/unreliable/failed when no messages arrive from the leader to the follower node.
-- `LeaderPingInterval` the maximum round trip time the leader sends AppendEntriesRequest and until it has to get the AppendEntriesResponse back from the follower. This has to be big enough to allow for the network round trip, as well as for the leader and follower to process the message. This time should be significantly smaller than `LeaderTimeout`.
-- `ElectionTimeoutMin` the minimum time at which the election could time out if the candidate did not collect a majority of votes.
-- `ElectionTimeoutMax` the maximum time at which the election could time out if the candidate did not collect a majority of votes. Each new election started by node `N` initalizes its election timeout to a random time span between the min and max values.
+- `LeaderTimeout` — time a follower waits without hearing from a leader before starting an election.
+- `LeaderPingInterval` — how often the leader sends heartbeats to followers.
+- `ElectionTimeoutMin` / `ElectionTimeoutMax` — randomised election timeout range (randomisation prevents split votes).
+- `LogSerializerType` — optionally override the serializer used for log entries (defaults to the configured `ISerializer`).
 
 ## Leader Request Delegation ASP.NET Core Middleware
 
 Package: [SlimCluster.AspNetCore](https://www.nuget.org/packages/SlimCluster.AspNetCore)
 
-ToDo
+In a Raft cluster, state-mutating operations must be executed on the leader node.
+This middleware automatically forwards matching HTTP requests from any follower node to the current leader, so client code does not need to know which node is the leader.
+
+### Setup
+
+1. Register the plugin during configuration:
+
+```cs
+cfg.AddAspNetCore(opts =>
+{
+    // Route all requests whose path contains "/Counter" to the leader node
+    opts.DelegateRequestToLeader = r => r.Path.HasValue && r.Path.Value.Contains("/Counter");
+});
+```
+
+2. Add the middleware to the ASP.NET Core pipeline (after `UseRouting`):
+
+```cs
+app.UseClusterLeaderRequestDelegation();
+```
+
+### Behaviour
+
+- If the current node **is the leader**, the request is handled locally — no forwarding occurs.
+- If the current node **is a follower**, the request is transparently proxied to the leader's address over HTTP.
+- If **no leader is currently known** (e.g. during an election), a `ClusterException` is thrown. The caller should retry after a short delay.
+
+### `DelegateRequestToLeader` predicate
+
+The predicate receives the `HttpRequest` and should return `true` for requests that must run on the leader. For example:
+
+```cs
+// Forward all write endpoints but let reads run locally
+opts.DelegateRequestToLeader = r =>
+    (r.Method == HttpMethods.Post || r.Method == HttpMethods.Put || r.Method == HttpMethods.Delete)
+    && r.Path.StartsWithSegments("/api");
+```

--- a/src/Common.NuGet.Properties.xml
+++ b/src/Common.NuGet.Properties.xml
@@ -3,11 +3,20 @@
   <Import Project="Common.Properties.xml" />
 
   <PropertyGroup>
-    <Version>0.9.0</Version>
+    <Version>1.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReadmeFile>NuGet.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
+    <!-- SourceLink: embed source info so IDE users can step into library source from NuGet -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\docs\NuGet.md" Pack="true" PackagePath="\"/>

--- a/src/Common.Properties.xml
+++ b/src/Common.Properties.xml
@@ -4,12 +4,13 @@
     <Product>SlimCluster</Product>
     <Company>zarusz</Company>
     <Authors>zarusz</Authors>
-    <Copyright>Copyright © 2023</Copyright>
+    <Copyright>Copyright © 2023-2026</Copyright>
     <PackageReleaseNotes>See https://github.com/zarusz/SlimCluster/releases</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/zarusz/SlimCluster</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/zarusz/SlimCluster</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
+++ b/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
@@ -163,8 +163,13 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
     {
         var majorityCount = _options.NodeCount / 2;
 
-        // ToDo: Do not take into acount inactive members
-        var orderedMatchIndexes = ReplicationStateByNode.Values.Select(x => x.MatchIndex).OrderByDescending(x => x).ToList();
+        // Include the leader's own match index (its last log index) alongside followers.
+        // ToDo: Do not take into account inactive members
+        var leaderMatchIndex = _logRepository.LastIndex.Index;
+        var orderedMatchIndexes = ReplicationStateByNode.Values.Select(x => x.MatchIndex)
+            .Append(leaderMatchIndex)
+            .OrderByDescending(x => x)
+            .ToList();
 
         var majorityMatchIndex = orderedMatchIndexes.FirstOrDefault(matchIndex =>
         {

--- a/src/SlimCluster.Consensus.Raft/RaftNode.cs
+++ b/src/SlimCluster.Consensus.Raft/RaftNode.cs
@@ -205,9 +205,14 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
             resp.Term = r.Term;
             if (_votedFor == null || _votedFor == node.Id)
             {
-                if (_logRepository.LastIndex.Index <= r.LastLogIndex)
+                // Raft §5.4.1: candidate log is up-to-date if its last term is higher,
+                // or same term but index is at least as long as ours.
+                var ourLastIndex = _logRepository.LastIndex;
+                var logIsUpToDate = r.LastLogTerm > ourLastIndex.Term
+                    || (r.LastLogTerm == ourLastIndex.Term && r.LastLogIndex >= ourLastIndex.Index);
+                if (logIsUpToDate)
                 {
-                    // Grant vote - sender's logs are at least as up to date as this nodes.
+                    // Grant vote - sender's log is at least as up to date as this node's.
                     resp.VoteGranted = true;
                     // Save who we given the vote to
                     _votedFor = node.Id;

--- a/src/SlimCluster.Membership.Swim/MembershipEventBuffer.cs
+++ b/src/SlimCluster.Membership.Swim/MembershipEventBuffer.cs
@@ -64,7 +64,7 @@ public class MembershipEventBuffer : IMembershipEventBuffer
                 return false;
             }
 
-            if (_items.Count + 1 < _items.Capacity)
+            if (_items.Count < _items.Capacity)
             {
                 _items.Add(newItem);
             }

--- a/src/SlimCluster.Membership.Swim/SwimClusterMembership.cs
+++ b/src/SlimCluster.Membership.Swim/SwimClusterMembership.cs
@@ -386,7 +386,7 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
         {
             // Recycle expired entries
             var now = _time.Now;
-            list.RemoveAll(x => x.ExpiresAt > now);
+            list.RemoveAll(x => x.ExpiresAt < now);
 
             // Add the current request
             list.Add(indirectPingRequest);

--- a/src/SlimCluster.Membership.Swim/SwimFailureDetector.cs
+++ b/src/SlimCluster.Membership.Swim/SwimFailureDetector.cs
@@ -102,7 +102,7 @@ public class SwimFailureDetector
         {
             var selectedMemberIndex = _random.Next(activeMembers.Count);
             var selectedMember = activeMembers[selectedMemberIndex];
-
+            selectedMembers.Add(selectedMember);
             activeMembers.RemoveAt(selectedMemberIndex);
         }
 

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderMajorityTests.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderMajorityTests.cs
@@ -1,0 +1,129 @@
+namespace SlimCluster.Consensus.Raft.Test;
+
+using SlimCluster.Transport;
+
+/// <summary>
+/// Tests for majority-based commit logic in RaftLeaderState.
+/// Verifies that the leader counts itself in the quorum, so a 3-node cluster
+/// commits after replication to just 1 follower (not requiring both).
+/// </summary>
+public class RaftLeaderMajorityTests : AbstractRaftIntegrationTest, IAsyncLifetime
+{
+    private readonly int _term = 1;
+    private readonly SerializerMock _logSerializerMock;
+    private readonly Mock<OnNewerTermDiscovered> _onNewerTermDiscovered;
+    private readonly RaftLeaderState _subject;
+
+    public RaftLeaderMajorityTests(ITestOutputHelper testOutputHelper)
+    {
+        _term = 1;
+        _logSerializerMock = new SerializerMock();
+        _onNewerTermDiscovered = new Mock<OnNewerTermDiscovered>();
+
+        _options.NodeCount = 3;
+        _options.LeaderPingInterval = TimeSpan.FromMilliseconds(200);
+
+        _subject = new RaftLeaderState(
+            XUnitLogger.CreateLogger<RaftLeaderState>(testOutputHelper),
+            _term,
+            _options,
+            _clusterMembershipMock.Object,
+            _messageSenderMock.Object,
+            _logRepositoryMock.Object,
+            _stateMachineMock.Object,
+            _logSerializerMock.Object,
+            new Time(),
+            _onNewerTermDiscovered.Object);
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => _subject.Stop();
+
+    /// <summary>
+    /// In a 3-node cluster the leader should commit once ONE follower replicates
+    /// (leader + 1 follower = 2 > 3/2 = 1, i.e. majority).
+    /// Before the fix this required BOTH followers to replicate (100%).
+    /// </summary>
+    [Fact]
+    public async Task Given_ThreeNodeCluster_When_OneFollowerReplicates_Then_EntryCommitted()
+    {
+        // arrange
+        var command = new object();
+        var commandPayload = new byte[] { 42 };
+        var commandResult = new object();
+
+        _logSerializerMock.SetupSerDes(command, commandPayload);
+        _stateMachineMock
+            .Setup(x => x.Apply(command, 1))
+            .ReturnsAsync(commandResult);
+
+        // node1 (index 0) replicates successfully; node2 (index 1) never advances past index 0
+        var replicatedByNode = new Dictionary<IAddress, int>();
+        foreach (var m in _otherMembers) replicatedByNode[m.Node.Address] = 0;
+
+        _messageSenderMock
+            .Setup(x => x.SendRequest(It.IsAny<AppendEntriesRequest>(), It.IsAny<IAddress>(), It.IsAny<TimeSpan?>()))
+            .ReturnsAsync((IRequest<AppendEntriesResponse> r, IAddress addr, TimeSpan? _) =>
+            {
+                var req = (AppendEntriesRequest)r;
+                if (addr.Equals(_otherMembers[0].Node.Address))
+                {
+                    // Follower 0 replicates normally
+                    var current = replicatedByNode[addr];
+                    var success = current >= req.PrevLogIndex;
+                    if (success)
+                        replicatedByNode[addr] = Math.Max(current, req.PrevLogIndex + (req.Entries?.Count ?? 0));
+                    return new AppendEntriesResponse((RaftMessage)r) { Success = success, Term = _term };
+                }
+                // Follower 1: always succeeds for heartbeats (no entries) but never advances past 0
+                // This prevents NextIndex from decrementing below 1
+                var hasEntries = req.Entries?.Count > 0;
+                return new AppendEntriesResponse((RaftMessage)r) { Success = !hasEntries, Term = _term };
+            });
+
+        await _subject.Start();
+        await Task.Delay(TimeSpan.FromMilliseconds(500)); // let heartbeats establish MatchIndex=0
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // act: submit a command — should complete once follower[0] confirms
+        var result = await _subject.OnClientRequest(command, cts.Token);
+
+        // assert: result returned (state machine applied), meaning commit happened with just 1 follower
+        result.Should().Be(commandResult);
+        _stateMachineMock.Verify(x => x.Apply(command, 1), Times.Once);
+    }
+
+    /// <summary>
+    /// Commit must NOT happen when zero followers have replicated (only leader has the entry).
+    /// With NodeCount=3, majority=2, leader alone is only 1 node.
+    /// </summary>
+    [Fact]
+    public async Task Given_ThreeNodeCluster_When_NoFollowerReplicates_Then_EntryNotCommitted()
+    {
+        // arrange
+        var command = new object();
+        var commandPayload = new byte[] { 99 };
+
+        _logSerializerMock.SetupSerDes(command, commandPayload);
+
+        // All followers always reject
+        _messageSenderMock
+            .Setup(x => x.SendRequest(It.IsAny<AppendEntriesRequest>(), It.IsAny<IAddress>(), It.IsAny<TimeSpan?>()))
+            .ReturnsAsync((IRequest<AppendEntriesResponse> r, IAddress _, TimeSpan? __) =>
+                new AppendEntriesResponse((RaftMessage)r) { Success = false, Term = _term });
+
+        await _subject.Start();
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(800));
+
+        // act: command should time out because no follower replicates
+        var act = () => _subject.OnClientRequest(command, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        // assert: state machine was never applied
+        _stateMachineMock.Verify(x => x.Apply(It.IsAny<object>(), It.IsAny<int>()), Times.Never);
+    }
+}

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/RaftNodeTests.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/RaftNodeTests.cs
@@ -204,7 +204,7 @@ public class RaftNodeTests : AbstractRaftIntegrationTest, IAsyncLifetime
     [Theory]
     [InlineData(0, 3, true)]
     [InlineData(0, 1, false)]
-    [InlineData(1, 1, false)]
+    [InlineData(1, 1, true)]  // higher last-log term beats higher index per Raft §5.4.1
     [InlineData(1, 3, true)]
     [InlineData(3, 3, true)]
     public async Task Given_Follower_When_RequestVoteRequest_Then_GrantsVote_IfHigherTerm_And_LogAtLeastAsFresh(int candidateTerm, int candidateIndex, bool voteGranted)
@@ -230,7 +230,6 @@ public class RaftNodeTests : AbstractRaftIntegrationTest, IAsyncLifetime
         _subject.Status.Should().Be(RaftNodeStatus.Follower); // still follower
         _subject.CurrentTerm.Should().Be(Math.Max(candidateTerm, currentTerm)); // next term was started
 
-        // request votes for prev term
         _messageSenderMock.Verify(x => x.SendMessage(It.Is<RequestVoteResponse>(r => r.VoteGranted == voteGranted && r.Term == Math.Max(candidateTerm, currentTerm)), candidate.Address), Times.Once());
         _messageSenderMock.VerifyNoOtherCalls();
     }
@@ -313,5 +312,198 @@ public class RaftNodeTests : AbstractRaftIntegrationTest, IAsyncLifetime
         _now = _now.Add(_options.LeaderTimeout).AddSeconds(1); // advance time
         await _subject.OnLoopRunProxy();
         // becomes a candidate
+    }
+
+    // -----------------------------------------------------------------------
+    // Vote granting — Raft §5.4.1 log up-to-date rule
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Candidate whose last log term is HIGHER than ours must be granted the vote
+    /// regardless of log length — the term comparison takes absolute precedence.
+    /// </summary>
+    [Theory]
+    // (ourTerm, ourIndex, candidateTerm, candidateIndex, expected)
+    [InlineData(1, 5, 2, 1, true)]   // higher candidate term wins even with shorter log
+    [InlineData(1, 5, 2, 5, true)]   // higher candidate term, equal index
+    [InlineData(1, 5, 2, 6, true)]   // higher candidate term, longer index
+    [InlineData(2, 5, 1, 10, false)]  // lower candidate term must be rejected even with longer log
+    [InlineData(2, 5, 2, 4, false)]  // same term, shorter log — reject
+    [InlineData(2, 5, 2, 5, true)]   // same term, equal index — grant
+    [InlineData(2, 5, 2, 6, true)]   // same term, longer log — grant
+    public async Task Given_Follower_When_RequestVoteRequest_Then_VoteGranted_AccordingTo_Raft_LogUpToDateRule(
+        int ourTerm, int ourIndex, int candidateTerm, int candidateIndex, bool expectedGranted)
+    {
+        // arrange: start as follower in ourTerm
+        _logRepositoryMock.SetupGet(x => x.LastIndex).Returns(new LogIndex(ourIndex, ourTerm));
+
+        // Put node in follower state at ourTerm
+        await _subject.OnLoopRunProxy();
+        // Advance to ourTerm by simulating an AppendEntries from a leader
+        if (ourTerm > 0)
+        {
+            var leader = _otherMembers[1].Node;
+            await _subject.OnMessageArrived(
+                new AppendEntriesRequest { Term = ourTerm, LeaderId = leader.Id, PrevLogIndex = 0, PrevLogTerm = 0 },
+                leader.Address);
+            await _subject.OnLoopRunProxy();
+        }
+        _messageSenderMock.Invocations.Clear();
+
+        var candidate = _otherMembers[0].Node;
+
+        // act
+        await _subject.OnMessageArrived(
+            new RequestVoteRequest
+            {
+                CandidateId = candidate.Id,
+                Term = candidateTerm,
+                LastLogIndex = candidateIndex,
+                LastLogTerm = candidateTerm
+            },
+            candidate.Address);
+        await _subject.OnLoopRunProxy();
+
+        // assert
+        _messageSenderMock.Verify(
+            x => x.SendMessage(
+                It.Is<RequestVoteResponse>(r => r.VoteGranted == expectedGranted),
+                candidate.Address),
+            Times.Once());
+    }
+
+    /// <summary>
+    /// A node must not grant a second vote in the same term once it has already voted.
+    /// </summary>
+    [Fact]
+    public async Task Given_Follower_AlreadyVotedInTerm_When_DifferentCandidateRequests_Then_VoteNotGranted()
+    {
+        // arrange
+        await _subject.OnLoopRunProxy(); // become follower
+
+        var currentTerm = _subject.CurrentTerm;
+        _logRepositoryMock.SetupGet(x => x.LastIndex).Returns(new LogIndex(0, 0));
+
+        var firstCandidate = _otherMembers[0].Node;
+        var secondCandidate = _otherMembers[1].Node;
+
+        // Vote for first candidate
+        await _subject.OnMessageArrived(
+            new RequestVoteRequest { CandidateId = firstCandidate.Id, Term = currentTerm + 1, LastLogIndex = 0, LastLogTerm = 0 },
+            firstCandidate.Address);
+        await _subject.OnLoopRunProxy();
+
+        _messageSenderMock.Verify(
+            x => x.SendMessage(It.Is<RequestVoteResponse>(r => r.VoteGranted), firstCandidate.Address),
+            Times.Once());
+
+        _messageSenderMock.Invocations.Clear();
+
+        // act: second candidate requests vote in the same term
+        await _subject.OnMessageArrived(
+            new RequestVoteRequest { CandidateId = secondCandidate.Id, Term = currentTerm + 1, LastLogIndex = 0, LastLogTerm = 0 },
+            secondCandidate.Address);
+        await _subject.OnLoopRunProxy();
+
+        // assert: vote denied
+        _messageSenderMock.Verify(
+            x => x.SendMessage(It.Is<RequestVoteResponse>(r => !r.VoteGranted), secondCandidate.Address),
+            Times.Once());
+    }
+
+    /// <summary>
+    /// A node that already voted in term T may vote again if it receives a request for term T+1
+    /// (UpdateTerm resets _votedFor).
+    /// </summary>
+    [Fact]
+    public async Task Given_Follower_AlreadyVotedInTerm_When_SameOrHigherTermRequest_Then_CanVoteAgain()
+    {
+        // arrange
+        await _subject.OnLoopRunProxy(); // become follower
+        _logRepositoryMock.SetupGet(x => x.LastIndex).Returns(new LogIndex(0, 0));
+
+        var candidate1 = _otherMembers[0].Node;
+        var candidate2 = _otherMembers[1].Node;
+        var term1 = _subject.CurrentTerm + 1;
+
+        // Vote in term1
+        await _subject.OnMessageArrived(
+            new RequestVoteRequest { CandidateId = candidate1.Id, Term = term1, LastLogIndex = 0, LastLogTerm = 0 },
+            candidate1.Address);
+        await _subject.OnLoopRunProxy();
+        _messageSenderMock.Invocations.Clear();
+
+        // act: different candidate requests vote for term1+1 — node's term advances, _votedFor resets
+        await _subject.OnMessageArrived(
+            new RequestVoteRequest { CandidateId = candidate2.Id, Term = term1 + 1, LastLogIndex = 0, LastLogTerm = 0 },
+            candidate2.Address);
+        await _subject.OnLoopRunProxy();
+
+        // assert: vote granted in new term
+        _messageSenderMock.Verify(
+            x => x.SendMessage(It.Is<RequestVoteResponse>(r => r.VoteGranted), candidate2.Address),
+            Times.Once());
+    }
+
+    // -----------------------------------------------------------------------
+    // AppendEntries — stale term rejection
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Given_Follower_When_AppendEntriesWithLowerTerm_Then_Rejected()
+    {
+        // arrange: become follower in a higher term first
+        await _subject.OnLoopRunProxy();
+        var leader = _otherMembers[1].Node;
+        _logRepositoryMock.SetupGet(x => x.LastIndex).Returns(new LogIndex(0, 0));
+
+        // Advance to term 3 via an AppendEntries
+        await _subject.OnMessageArrived(
+            new AppendEntriesRequest { Term = 3, LeaderId = leader.Id, PrevLogIndex = 0, PrevLogTerm = 0 },
+            leader.Address);
+        await _subject.OnLoopRunProxy();
+        _messageSenderMock.Invocations.Clear();
+
+        // act: stale AppendEntries from term 1
+        var staleSender = _otherMembers[0].Node;
+        await _subject.OnMessageArrived(
+            new AppendEntriesRequest { Term = 1, LeaderId = staleSender.Id, PrevLogIndex = 0, PrevLogTerm = 0 },
+            staleSender.Address);
+        await _subject.OnLoopRunProxy();
+
+        // assert: rejected (Success=false) and current higher term returned
+        _messageSenderMock.Verify(
+            x => x.SendMessage(
+                It.Is<AppendEntriesResponse>(r => !r.Success && r.Term == 3),
+                staleSender.Address),
+            Times.Once());
+    }
+
+    // -----------------------------------------------------------------------
+    // Follower: leader timeout resets when heartbeat arrives
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Given_Follower_When_AppendEntriesArrives_Then_ElectionTimerResets_And_StaysFollower()
+    {
+        // arrange
+        await _subject.OnLoopRunProxy(); // become follower
+        _logRepositoryMock.SetupGet(x => x.LastIndex).Returns(new LogIndex(0, 0));
+
+        var leader = _otherMembers[1].Node;
+
+        // Advance time past leader timeout
+        _now = _now.Add(_options.LeaderTimeout).AddSeconds(1);
+
+        // But deliver a heartbeat before DoRun processes the timeout
+        await _subject.OnMessageArrived(
+            new AppendEntriesRequest { Term = _subject.CurrentTerm, LeaderId = leader.Id, PrevLogIndex = 0, PrevLogTerm = 0 },
+            leader.Address);
+
+        // act
+        var idleRun = await _subject.OnLoopRunProxy();
+
+        // assert: stays follower, does not become candidate
+        _subject.Status.Should().Be(RaftNodeStatus.Follower);
     }
 }

--- a/src/Tests/SlimCluster.Membership.Swim.Test/SwimFailureDetectorTests.cs
+++ b/src/Tests/SlimCluster.Membership.Swim.Test/SwimFailureDetectorTests.cs
@@ -1,0 +1,186 @@
+namespace SlimCluster.Membership.Swim.Tests;
+
+using Microsoft.Extensions.Logging;
+using SlimCluster.Membership.Swim.Messages;
+using SlimCluster.Transport;
+using SlimCluster.Transport.Ip;
+
+public class SwimFailureDetectorTests
+{
+    private readonly DateTimeOffset _now = DateTimeOffset.Parse("2024-01-01T00:00:00Z");
+    private readonly SwimClusterMembershipOptions _options;
+    private readonly Mock<IMessageSender> _messageSenderMock;
+    private readonly Mock<ITime> _timeMock;
+    private readonly Mock<ICurrentNode> _currentNodeMock;
+
+    private readonly ILogger<SwimFailureDetector> _logger = NullLogger<SwimFailureDetector>.Instance;
+
+    private static SwimMember MakeMember(string id, string address, SwimMemberStatus? status = null)
+    {
+        var member = new SwimMember(
+            id,
+            IPEndPointAddress.Parse(address),
+            DateTimeOffset.UtcNow,
+            status ?? SwimMemberStatus.Active,
+            null,
+            NullLogger<SwimMember>.Instance);
+        return member;
+    }
+
+    public SwimFailureDetectorTests()
+    {
+        _options = new SwimClusterMembershipOptions
+        {
+            ProtocolPeriod = TimeSpan.FromSeconds(5),
+            PingAckTimeout = TimeSpan.FromSeconds(1),
+            FailureDetectionSubgroupSize = 2,
+        };
+
+        _messageSenderMock = new Mock<IMessageSender>();
+        _timeMock = new Mock<ITime>();
+        _currentNodeMock = new Mock<ICurrentNode>();
+
+        _timeMock.SetupGet(x => x.Now).Returns(() => _now);
+        _currentNodeMock.SetupGet(x => x.Id).Returns("self");
+    }
+
+    private SwimFailureDetector CreateSubject(IReadOnlyList<SwimMember> members)
+        => new(_logger, _options, _messageSenderMock.Object, members, _currentNodeMock.Object, _timeMock.Object);
+
+    // -----------------------------------------------------------------------
+    // OnPingTimeout: selected members are populated and PingReq is sent
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Given_PingTimeout_When_ActiveMembersExist_Then_PingReqSentToSubgroup()
+    {
+        // arrange
+        var node1 = MakeMember("node1", "10.0.0.1:6000");
+        var node2 = MakeMember("node2", "10.0.0.2:6000");
+        var node3 = MakeMember("node3", "10.0.0.3:6000");
+        var pingTarget = MakeMember("target", "10.0.0.9:6000");
+
+        // Start the target as Active so it gets selected for pinging
+        var allMembers = new List<SwimMember> { node1, node2, node3, pingTarget };
+
+        var subject = CreateSubject(allMembers);
+
+        // Advance time to trigger a new period — this selects pingTarget for probing
+        var periodStart = _now;
+        var afterPeriod = periodStart.Add(_options.ProtocolPeriod).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterPeriod);
+
+        _messageSenderMock
+            .Setup(x => x.SendMessage(It.IsAny<SwimMessage>(), It.IsAny<IAddress>()))
+            .Returns(Task.CompletedTask);
+
+        // Run to trigger OnNewPeriod → SelectMemberForPing → sends Ping
+        await subject.DoRun();
+
+        // Now advance past the pingAckTimeout
+        var afterPingAck = afterPeriod.Add(_options.PingAckTimeout).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterPingAck);
+
+        _messageSenderMock.Invocations.Clear();
+
+        // act: DoRun should fire OnPingTimeout which should send PingReq messages
+        await subject.DoRun();
+
+        // assert: PingReq was sent to at most FailureDetectionSubgroupSize members (not zero!)
+        _messageSenderMock.Verify(
+            x => x.SendMessage(It.IsAny<PingReqMessage>(), It.IsAny<IAddress>()),
+            Times.Between(1, _options.FailureDetectionSubgroupSize, Moq.Range.Inclusive));
+    }
+
+    [Fact]
+    public async Task Given_PingTimeout_When_SubgroupSizeLargerThanMembers_Then_PingReqSentToAllActiveMembers()
+    {
+        // arrange: only 1 other active member, subgroup size is 2
+        var onlyOther = MakeMember("other", "10.0.0.1:6000");
+
+        // pingTarget is separate so it becomes the ping node, not the subgroup node
+        var pingTarget = MakeMember("target", "10.0.0.9:6000");
+
+        var subject = CreateSubject(new List<SwimMember> { onlyOther, pingTarget });
+
+        _messageSenderMock
+            .Setup(x => x.SendMessage(It.IsAny<SwimMessage>(), It.IsAny<IAddress>()))
+            .Returns(Task.CompletedTask);
+
+        var afterPeriod = _now.Add(_options.ProtocolPeriod).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterPeriod);
+        await subject.DoRun(); // trigger new period, select one of them for ping
+
+        var afterAck = afterPeriod.Add(_options.PingAckTimeout).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterAck);
+
+        _messageSenderMock.Invocations.Clear();
+
+        // act
+        await subject.DoRun();
+
+        // assert: exactly 1 PingReq sent (only one eligible member remains after removing ping node)
+        _messageSenderMock.Verify(
+            x => x.SendMessage(It.IsAny<PingReqMessage>(), It.IsAny<IAddress>()),
+            Times.AtMostOnce());
+    }
+
+    // -----------------------------------------------------------------------
+    // OnNewPeriod: node is declared Faulted if Confirming and no Ack arrived
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Given_NodeIsConfirming_When_NewPeriodStarts_Then_NodeDeclaredFaulted()
+    {
+        // arrange
+        var statusChanges = new List<SwimMemberStatus>();
+        var pingTarget = new SwimMember(
+            "target", IPEndPointAddress.Parse("10.0.0.9:6000"),
+            _now, SwimMemberStatus.Active,
+            m => statusChanges.Add(m.SwimStatus),
+            NullLogger<SwimMember>.Instance);
+
+        var subject = CreateSubject(new List<SwimMember> { pingTarget });
+
+        _messageSenderMock
+            .Setup(x => x.SendMessage(It.IsAny<SwimMessage>(), It.IsAny<IAddress>()))
+            .Returns(Task.CompletedTask);
+
+        // Trigger first period — SelectMemberForPing picks pingTarget and sends Ping
+        var afterPeriod1 = _now.Add(_options.ProtocolPeriod).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterPeriod1);
+        await subject.DoRun();
+
+        // Ack timeout fires — pingTarget transitions to Confirming
+        var afterAck = afterPeriod1.Add(_options.PingAckTimeout).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterAck);
+        await subject.DoRun();
+
+        // Second period starts — pingTarget has not responded, declared Faulted
+        var afterPeriod2 = afterAck.Add(_options.ProtocolPeriod).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterPeriod2);
+        await subject.DoRun();
+
+        // assert
+        pingTarget.SwimStatus.Should().Be(SwimMemberStatus.Faulted);
+    }
+
+    // -----------------------------------------------------------------------
+    // DoRun: idle vs non-idle based on time
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0, true)]   // within period — idle
+    [InlineData(6, false)]  // period expired — not idle
+    public async Task Given_DoRun_When_TimeAdvanced_Then_IdleMatchesPeriodState(int secondsElapsed, bool expectedIdle)
+    {
+        var subject = CreateSubject(new List<SwimMember>());
+
+        if (secondsElapsed > 0)
+            _timeMock.SetupGet(x => x.Now).Returns(_now.AddSeconds(secondsElapsed));
+
+        var isIdle = await subject.DoRun();
+
+        isIdle.Should().Be(expectedIdle);
+    }
+}

--- a/src/Tests/SlimCluster.Membership.Swim.Test/SwimGossipTests.cs
+++ b/src/Tests/SlimCluster.Membership.Swim.Test/SwimGossipTests.cs
@@ -57,12 +57,19 @@ public class SwimGossipTests
         _membershipEventListenerMock.VerifyNoOtherCalls();
     }
 
-    [Fact]
-    public void When_OnMessageSending_Given_PingMessage_And_MembershipEvents_Then_AddsToMessage()
+    public static TheoryData<Messages.SwimMessage> MessagesSupportingGossip =>
+        new()
+        {
+            new Messages.PingMessage("node0"),
+            new Messages.AckMessage("node0"),
+            new Messages.PingReqMessage("node0"),
+        };
+
+    [Theory]
+    [MemberData(nameof(MessagesSupportingGossip))]
+    public void When_OnMessageSending_Given_MessageWithGossipSupport_Then_EventsAddedToMessage(Messages.SwimMessage msg)
     {
         // arrange
-        var msg = new Messages.PingMessage("node0");
-
         var events = new List<Messages.MembershipEvent>();
         _membershipEventBufferMock.Setup(x => x.GetNextEvents(It.IsAny<int>())).Returns(events);
 
@@ -70,38 +77,6 @@ public class SwimGossipTests
         subject.OnMessageSending(msg);
 
         // assert
-        msg.Events.Should().BeSameAs(events);
-    }
-
-    [Fact]
-    public void When_OnMessageSending_Given_AckMessage_And_MembershipEvents_Then_AddsToMessage()
-    {
-        // arrange
-        var msg = new Messages.AckMessage("node0");
-
-        var events = new List<Messages.MembershipEvent>();
-        _membershipEventBufferMock.Setup(x => x.GetNextEvents(It.IsAny<int>())).Returns(events);
-
-        // act
-        subject.OnMessageSending(msg);
-
-        // assert
-        msg.Events.Should().BeSameAs(events);
-    }
-
-    [Fact]
-    public void When_OnMessageSending_Given_PingReqMessage_And_MembershipEvents_Then_AddsToMessage()
-    {
-        // arrange
-        var msg = new Messages.PingReqMessage("node0");
-
-        var events = new List<Messages.MembershipEvent>();
-        _membershipEventBufferMock.Setup(x => x.GetNextEvents(It.IsAny<int>())).Returns(events);
-
-        // act
-        subject.OnMessageSending(msg);
-
-        // assert
-        msg.Events.Should().BeSameAs(events);
+        ((Messages.IHasMembershipEvents)msg).Events.Should().BeSameAs(events);
     }
 }

--- a/src/Tests/SlimCluster.Membership.Swim.Test/SwimMembershipEventBufferTests.cs
+++ b/src/Tests/SlimCluster.Membership.Swim.Test/SwimMembershipEventBufferTests.cs
@@ -73,4 +73,97 @@ public class SwimMembershipEventBufferTests
             && x.Type == Messages.MembershipEventType.Joined 
             && x.Timestamp == _now.AddMinutes(2));
     }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(20)]
+    public void Given_Buffer_When_FilledToCapacity_Then_AllSlotsUsed(int capacity)
+    {
+        // arrange
+        var subject = new MembershipEventBuffer(capacity);
+
+        // act
+        for (var i = 0; i < capacity; i++)
+        {
+            var added = subject.Add(new Messages.MembershipEvent($"node{i}", Messages.MembershipEventType.Joined, _now));
+            added.Should().BeTrue($"slot {i} should fit in a buffer of capacity {capacity}");
+        }
+
+        var events = subject.GetNextEvents(capacity + 1);
+        events.Should().HaveCount(capacity, "buffer should hold all {0} events", capacity);
+    }
+
+    [Fact]
+    public void Given_FullBuffer_When_AddNewEvent_Then_ReplacesHighestUsedEntry()
+    {
+        // arrange
+        var subject = new MembershipEventBuffer(3);
+
+        subject.Add(new Messages.MembershipEvent("node1", Messages.MembershipEventType.Joined, _now));
+        subject.Add(new Messages.MembershipEvent("node2", Messages.MembershipEventType.Joined, _now));
+        subject.Add(new Messages.MembershipEvent("node3", Messages.MembershipEventType.Joined, _now));
+
+        // drive up UsedCount for node1 by calling GetNextEvents multiple times
+        subject.GetNextEvents(3); // all used once
+        subject.GetNextEvents(3); // all used twice — node1 should be first returned each time due to ordering, but all equal here
+
+        // Now get only 1 to further bump one entry  
+        // Actually GetNextEvents uses least-used ordering — let's just call enough times
+        // to ensure node1 has higher UsedCount than others
+        for (var i = 0; i < 5; i++) subject.GetNextEvents(1); // bumps the least-used one repeatedly
+
+        // act: add event for a new node (node4) — should evict the highest used entry
+        var added = subject.Add(new Messages.MembershipEvent("node4", Messages.MembershipEventType.Joined, _now.AddMinutes(10)));
+
+        // assert
+        added.Should().BeTrue();
+        var remaining = subject.GetNextEvents(10);
+        remaining.Should().HaveCount(3);
+        remaining.Should().Contain(x => x.NodeId == "node4");
+    }
+
+    /// <summary>
+    /// When two events arrive for the same node, the one with the newer timestamp wins.
+    /// A duplicate or older event should be ignored (returns false).
+    /// Parameters: (firstType, firstOffsetMinutes, secondType, secondOffsetMinutes, expectedAddedResult, expectedSurvivingType)
+    /// </summary>
+    [Theory]
+    [InlineData(Messages.MembershipEventType.Joined,  0, Messages.MembershipEventType.Faulted, 1, true,  Messages.MembershipEventType.Faulted)]  // newer replaces older
+    [InlineData(Messages.MembershipEventType.Faulted, 1, Messages.MembershipEventType.Joined,  0, false, Messages.MembershipEventType.Faulted)]  // older is ignored
+    [InlineData(Messages.MembershipEventType.Joined,  0, Messages.MembershipEventType.Joined,  0, false, Messages.MembershipEventType.Joined)]   // exact duplicate is ignored
+    public void Given_TwoEventsForSameNode_When_Add_Then_CorrectEventSurvives(
+        Messages.MembershipEventType firstType,  int firstOffsetMinutes,
+        Messages.MembershipEventType secondType, int secondOffsetMinutes,
+        bool expectedAdded,
+        Messages.MembershipEventType expectedSurvivingType)
+    {
+        var subject = new MembershipEventBuffer(10);
+
+        subject.Add(new Messages.MembershipEvent("node1", firstType,  _now.AddMinutes(firstOffsetMinutes)));
+
+        // act
+        var added = subject.Add(new Messages.MembershipEvent("node1", secondType, _now.AddMinutes(secondOffsetMinutes)));
+
+        // assert
+        added.Should().Be(expectedAdded);
+        var events = subject.GetNextEvents(10);
+        events.Should().HaveCount(1);
+        events.Single().Type.Should().Be(expectedSurvivingType);
+    }
+
+    [Fact]
+    public void Given_Events_When_GetNextEvents_Then_UsedCountIncremented()
+    {
+        var subject = new MembershipEventBuffer(10);
+        subject.Add(new Messages.MembershipEvent("node1", Messages.MembershipEventType.Joined, _now));
+
+        subject.GetNextEvents(5);
+        subject.GetNextEvents(5);
+
+        var fieldInfo = typeof(MembershipEventBuffer).GetField("_items", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var items = (List<MembershipEventBuffer.BufferItem>)fieldInfo.GetValue(subject)!;
+
+        items.Single().UsedCount.Should().Be(2);
+    }
 }


### PR DESCRIPTION
**Bug fixes**
- SWIM: `SwimFailureDetector` — PingReq subgroup list was never populated (indirect probes never sent)
- SWIM: `SwimClusterMembership` — inverted expiration check caused memory leak in indirect ping requests
- SWIM: `MembershipEventBuffer` — off-by-one prevented the last buffer slot from ever being used
- Raft: `RaftNode` — vote granted based on log index only, ignoring term (Raft §5.4.1 violation)
- Raft: `RaftLeaderState` — leader excluded from majority calculation (required 100% follower replication)

**Tests**
- Added 26 new tests across SWIM and Raft (39 → 65 total)
- Consolidated duplicate `[Fact]` tests into parameterised `[Theory]` tests
- Fixed a `TaskLoopTests` race condition causing intermittent CI failures

**NuGet manifest**
- Fixed copyright year, `RepositoryType=git`, `PackageRequireLicenseAcceptance=false`
- Added SourceLink + `.snupkg` symbol package support

**Docs**
- Filled in all `ToDo` stubs in intro.md (SWIM membership, static membership, ASP.NET Core middleware)
- Fixed typos; expanded Raft configuration parameter descriptions