### PR TITLE
Harden SWIM membership protocol handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Instructions
+
+- Name new git branches with the `feature/` prefix unless the user explicitly asks for a different branch name.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ ClusterMembership.MemberStatusChanged += (target, e) =>
 {
     if (e.Node.Status == SwimMemberStatus.Suspicious)
     {
-        Logger.LogInformation("The node {NodeId} is suspicious. All active members are: {NodeList}", e.Node.Id, string.Join(", ", ClusterMembership.Members.Where(x => x.Node.Status == SwimMemberStatus.Active)));
+        Logger.LogInformation("The node {NodeId} is suspicious after its direct probe timed out. All active members are: {NodeList}", e.Node.Id, string.Join(", ", ClusterMembership.Members.Where(x => x.Node.Status == SwimMemberStatus.Active)));
     }
 };
 ```

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -181,7 +181,7 @@ Package: [SlimCluster.Membership.Swim](https://www.nuget.org/packages/SlimCluste
 
 SWIM (Scalable Weakly-consistent Infection-style Membership) is a gossip-based protocol for detecting node failures and maintaining the cluster member list without a central coordinator.
 Each node periodically probes a random peer (Ping). If no Ack is received within the timeout, it sends indirect probes via a subgroup of other members (PingReq).
-Membership change events (joins, departures, failures) are piggybacked onto these protocol messages and eventually propagate to every node.
+Membership change events (joins, departures, failures) are piggybacked onto these protocol messages and eventually propagate to every node. Events include a node incarnation number so newer observations for a node supersede stale gossip even if messages arrive out of order.
 
 To add the SWIM plugin register it:
 
@@ -204,6 +204,8 @@ All properties are on `SwimClusterMembershipOptions`:
 | `MembershipEventBufferCount`    | `20`    | Size of the per-node event buffer used for gossip propagation.                                      |
 | `MembershipEventPiggybackCount` | `3`     | How many buffered events are piggybacked on each Ping/Ack message.                                  |
 
+Options are validated at startup. `ProtocolPeriod`, `PingAckTimeout`, and `MembershipEventBufferCount` must be greater than zero; `PingAckTimeout` must be shorter than `ProtocolPeriod`; subgroup and piggyback counts cannot be negative.
+
 ### Member Statuses
 
 SWIM nodes transition through the following statuses:
@@ -211,8 +213,8 @@ SWIM nodes transition through the following statuses:
 | Status       | `IsActive` | Meaning                                                                 |
 | ------------ | ---------- | ----------------------------------------------------------------------- |
 | `Active`     | ✓          | Node is responding normally.                                            |
-| `Suspicious` | ✗          | Direct probe failed; indirect probes are in-flight.                     |
-| `Confirming` | ✓          | Node was suspected but has since replied; waiting for confirmation.     |
+| `Confirming` | ✓          | Node is being directly probed and is still eligible as a live member.   |
+| `Suspicious` | ✗          | Direct probe timed out; indirect probes are in-flight if helpers exist. |
 | `Faulted`    | ✗          | No probe succeeded within the protocol period; node is considered dead. |
 
 ### Observing Membership Changes

--- a/src/Samples/SlimCluster.Samples.Service/MainApp.cs
+++ b/src/Samples/SlimCluster.Samples.Service/MainApp.cs
@@ -32,7 +32,7 @@ public record MainApp(ILogger<MainApp> Logger, IClusterMembership ClusterMembers
         {
             if (e.Node.Status == SwimMemberStatus.Suspicious)
             {
-                Logger.LogInformation("The node {NodeId} is suspicious. All active members are: {NodeList}", e.Node.Id, string.Join(", ", ClusterMembership.Members.Where(x => x.Node.Status == SwimMemberStatus.Active)));
+                Logger.LogInformation("The node {NodeId} is suspicious after its direct probe timed out. All active members are: {NodeList}", e.Node.Id, string.Join(", ", ClusterMembership.Members.Where(x => x.Node.Status == SwimMemberStatus.Active)));
             }
         };
         // doc:fragment:ExampleMembershipChanges

--- a/src/SlimCluster.Membership.Swim/Configuration/ClusterConfigurationExtensions.cs
+++ b/src/SlimCluster.Membership.Swim/Configuration/ClusterConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 using SlimCluster.Host;
 using SlimCluster.Membership.Swim.Messages;
@@ -16,6 +17,7 @@ public static class ClusterConfigurationExtensions
         cfg.PostConfigurationActions.Add(services =>
         {
             services.Configure(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<SwimClusterMembershipOptions>, SwimClusterMembershipOptionsValidator>());
 
             services.AddSingleton<SwimClusterMembership>();
 

--- a/src/SlimCluster.Membership.Swim/Configuration/SwimClusterMembershipOptionsValidator.cs
+++ b/src/SlimCluster.Membership.Swim/Configuration/SwimClusterMembershipOptionsValidator.cs
@@ -1,0 +1,45 @@
+namespace SlimCluster.Membership.Swim;
+
+using Microsoft.Extensions.Options;
+
+public class SwimClusterMembershipOptionsValidator : IValidateOptions<SwimClusterMembershipOptions>
+{
+    public ValidateOptionsResult Validate(string? name, SwimClusterMembershipOptions options)
+    {
+        var failures = new List<string>();
+
+        if (options.ProtocolPeriod <= TimeSpan.Zero)
+        {
+            failures.Add($"{nameof(options.ProtocolPeriod)} must be greater than zero.");
+        }
+
+        if (options.PingAckTimeout <= TimeSpan.Zero)
+        {
+            failures.Add($"{nameof(options.PingAckTimeout)} must be greater than zero.");
+        }
+
+        if (options.ProtocolPeriod > TimeSpan.Zero && options.PingAckTimeout >= options.ProtocolPeriod)
+        {
+            failures.Add($"{nameof(options.PingAckTimeout)} must be less than {nameof(options.ProtocolPeriod)}.");
+        }
+
+        if (options.FailureDetectionSubgroupSize < 0)
+        {
+            failures.Add($"{nameof(options.FailureDetectionSubgroupSize)} must not be negative.");
+        }
+
+        if (options.MembershipEventBufferCount <= 0)
+        {
+            failures.Add($"{nameof(options.MembershipEventBufferCount)} must be greater than zero.");
+        }
+
+        if (options.MembershipEventPiggybackCount < 0)
+        {
+            failures.Add($"{nameof(options.MembershipEventPiggybackCount)} must not be negative.");
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/SlimCluster.Membership.Swim/IMembershipEventListener.cs
+++ b/src/SlimCluster.Membership.Swim/IMembershipEventListener.cs
@@ -5,3 +5,9 @@ public interface IMembershipEventListener
     Task OnNodeJoined(string nodeId, IAddress senderAddress);
     Task OnNodeLeft(string nodeId);
 }
+
+public interface IIncarnationMembershipEventListener : IMembershipEventListener
+{
+    Task OnNodeJoined(string nodeId, IAddress senderAddress, long incarnation);
+    Task OnNodeLeft(string nodeId, long incarnation);
+}

--- a/src/SlimCluster.Membership.Swim/IndirectPingRequest.cs
+++ b/src/SlimCluster.Membership.Swim/IndirectPingRequest.cs
@@ -7,16 +7,18 @@ public class IndirectPingRequest : IHasPeriodSequenceNumber
     public long PeriodSequenceNumber { get; set; }
     public IAddress RequestingEndpoint { get; private set; }
     public IAddress TargetEndpoint { get; private set; }
+    public string TargetNodeId { get; private set; }
     /// <summary>
     /// Time after which the request is no longer needed
     /// </summary>
     public DateTimeOffset ExpiresAt { get; private set; }
 
-    public IndirectPingRequest(long periodSequenceNumber, IAddress requestingAddress, IAddress targetAddress, DateTimeOffset expiresAt)
+    public IndirectPingRequest(long periodSequenceNumber, IAddress requestingAddress, IAddress targetAddress, string targetNodeId, DateTimeOffset expiresAt)
     {
         PeriodSequenceNumber = periodSequenceNumber;
         RequestingEndpoint = requestingAddress;
         TargetEndpoint = targetAddress;
+        TargetNodeId = targetNodeId;
         ExpiresAt = expiresAt;
     }
 }

--- a/src/SlimCluster.Membership.Swim/MembershipEventBuffer.cs
+++ b/src/SlimCluster.Membership.Swim/MembershipEventBuffer.cs
@@ -32,6 +32,11 @@ public class MembershipEventBuffer : IMembershipEventBuffer
 
     public MembershipEventBuffer(int bufferSize)
     {
+        if (bufferSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bufferSize), bufferSize, "Membership event buffer size must be greater than zero.");
+        }
+
         _items = new List<BufferItem>(bufferSize);
     }
 
@@ -55,8 +60,8 @@ public class MembershipEventBuffer : IMembershipEventBuffer
             var indexOfNodeEvent = _items.FindIndex(x => x.MemberEvent.NodeId == e.NodeId);
             if (indexOfNodeEvent != -1)
             {
-                // Replace the previous event for the same node (prefer younger event)
-                if (_items[indexOfNodeEvent].MemberEvent.Timestamp < newItem.MemberEvent.Timestamp)
+                // Replace the previous event for the same node only when the incarnation is newer.
+                if (newItem.MemberEvent.IsNewerThan(_items[indexOfNodeEvent].MemberEvent))
                 {
                     _items[indexOfNodeEvent] = newItem;
                     return true;

--- a/src/SlimCluster.Membership.Swim/Messages/MembershipEvent.cs
+++ b/src/SlimCluster.Membership.Swim/Messages/MembershipEvent.cs
@@ -15,6 +15,9 @@ public class MembershipEvent : IHasNodeId, IHasTimestamp
 
     public DateTimeOffset Timestamp { get; set; }
 
+    [JsonProperty("inc")]
+    public long Incarnation { get; set; }
+
     [JsonProperty("typ")]
     public MembershipEventType Type { get; set; }
 
@@ -29,11 +32,22 @@ public class MembershipEvent : IHasNodeId, IHasTimestamp
     {
     }
 
-    public MembershipEvent(string nodeId, MembershipEventType type, DateTimeOffset timestamp)
+    public MembershipEvent(string nodeId, MembershipEventType type, DateTimeOffset timestamp, long incarnation = 0)
     {
         EventId = Guid.NewGuid();
         NodeId = nodeId;
         Timestamp = timestamp;
+        Incarnation = incarnation;
         Type = type;
+    }
+
+    public bool IsNewerThan(MembershipEvent other)
+    {
+        if (Incarnation != other.Incarnation)
+        {
+            return Incarnation > other.Incarnation;
+        }
+
+        return Timestamp > other.Timestamp;
     }
 }

--- a/src/SlimCluster.Membership.Swim/Messages/NodeJoinedMessage.cs
+++ b/src/SlimCluster.Membership.Swim/Messages/NodeJoinedMessage.cs
@@ -2,9 +2,15 @@
 
 public class NodeJoinedMessage : SwimMessage
 {
+    public long Incarnation { get; set; }
+
     protected NodeJoinedMessage()
     {
     }
 
-    public NodeJoinedMessage(string fromNodeId) => FromNodeId = fromNodeId;
+    public NodeJoinedMessage(string fromNodeId, long incarnation = 0)
+        : base(fromNodeId)
+    {
+        Incarnation = incarnation;
+    }
 }

--- a/src/SlimCluster.Membership.Swim/Messages/NodeLeftMessage.cs
+++ b/src/SlimCluster.Membership.Swim/Messages/NodeLeftMessage.cs
@@ -2,9 +2,15 @@
 
 public class NodeLeftMessage : SwimMessage
 {
+    public long Incarnation { get; set; }
+
     protected NodeLeftMessage()
     {
     }
-    
-    public NodeLeftMessage(string fromNodeId) => FromNodeId = fromNodeId;
+
+    public NodeLeftMessage(string fromNodeId, long incarnation = 0)
+        : base(fromNodeId)
+    {
+        Incarnation = incarnation;
+    }
 }

--- a/src/SlimCluster.Membership.Swim/Messages/PingReqMessage.cs
+++ b/src/SlimCluster.Membership.Swim/Messages/PingReqMessage.cs
@@ -1,6 +1,8 @@
 ﻿namespace SlimCluster.Membership.Swim.Messages;
-public class PingReqMessage : PingMessage, IHasNodeAddress
+public class PingReqMessage : PingMessage, IHasNodeAddress, IHasNodeId
 {
+    public string NodeId { get; set; } = string.Empty;
+
     /// <summary>
     /// Node address that sent this Ping
     /// </summary>

--- a/src/SlimCluster.Membership.Swim/SwimClusterMembership.cs
+++ b/src/SlimCluster.Membership.Swim/SwimClusterMembership.cs
@@ -14,7 +14,7 @@ using SlimCluster.Transport;
 /// <summary>
 /// The SWIM algorithm implementation of <see cref="IClusterMembership"/> for maintaining membership.
 /// </summary>
-public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterControlComponent, IAsyncDisposable, IMembershipEventListener, IMessageSendingHandler, IMessageArrivedHandler, IDurableComponent
+public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterControlComponent, IAsyncDisposable, IIncarnationMembershipEventListener, IMessageSendingHandler, IMessageArrivedHandler, IDurableComponent
 {
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<SwimClusterMembership> _logger;
@@ -160,7 +160,7 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
         // ToDo: Introduce an option to either use multicast or initial list of nodes seed
 
         // Announce (multicast) to others that this node joined the network
-        return SendToMulticastGroup(new NodeJoinedMessage(_selfMember.Id));
+        return SendToMulticastGroup(new NodeJoinedMessage(_selfMember.Id, _selfMember.Incarnation));
     }
 
     protected Task NotifySelfLeft()
@@ -168,7 +168,7 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
         // ToDo: Improvement - send message about leaving to N randomly selected nodes.
 
         // Announce (multicast) to others that this node left the network
-        return SendToMulticastGroup(new NodeLeftMessage(_selfMember.Id));
+        return SendToMulticastGroup(new NodeLeftMessage(_selfMember.Id, _selfMember.Incarnation));
     }
 
     private async Task SendToMulticastGroup(SwimMessage message)
@@ -186,8 +186,8 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
 
         var task = msg switch
         {
-            NodeJoinedMessage m => OnNodeJoined(m.FromNodeId, remoteAddress, addToEventBuffer: true),
-            NodeLeftMessage m => OnNodeLeft(m.FromNodeId, addToEventBuffer: true),
+            NodeJoinedMessage m => OnNodeJoined(m.FromNodeId, remoteAddress, m.Incarnation, addToEventBuffer: true),
+            NodeLeftMessage m => OnNodeLeft(m.FromNodeId, m.Incarnation, addToEventBuffer: true),
             PingReqMessage m => OnPingReq(m, remoteAddress),
             PingMessage m => OnPing(m, remoteAddress),
             AckMessage m => OnAck(m, remoteAddress),
@@ -206,15 +206,18 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
         }
     }
 
-    protected SwimMember CreateMember(string nodeId, IAddress address)
-        => new(nodeId, address, _time.Now, SwimMemberStatus.Active, OnMemberStatusChanged, _loggerFactory.CreateLogger<SwimMember>());
+    protected SwimMember CreateMember(string nodeId, IAddress address, long incarnation)
+        => new(nodeId, address, _time.Now, SwimMemberStatus.Active, OnMemberStatusChanged, _loggerFactory.CreateLogger<SwimMember>(), incarnation);
+
+    public Task OnNodeJoined(string nodeId, IAddress senderAddress, long incarnation = 0)
+        => OnNodeJoined(nodeId, senderAddress, incarnation, addToEventBuffer: false);
 
     public Task OnNodeJoined(string nodeId, IAddress senderAddress)
-        => OnNodeJoined(nodeId, senderAddress, addToEventBuffer: false);
+        => OnNodeJoined(nodeId, senderAddress, incarnation: 0);
 
-    protected Task OnNodeJoined(string nodeId, IAddress senderAddress, bool addToEventBuffer)
+    protected Task OnNodeJoined(string nodeId, IAddress senderAddress, long incarnation, bool addToEventBuffer)
     {
-        var member = EnsureNodeOnMemberlist(nodeId, senderAddress);
+        var member = EnsureNodeOnMemberlist(nodeId, senderAddress, incarnation);
 
         // Add other members only
         if (member.Id != _selfMember.Id)
@@ -224,17 +227,20 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
             if (addToEventBuffer)
             {
                 // Notify the member joined
-                _gossip?.MembershipEventBuffer.Add(new MembershipEvent(member.Id, MembershipEventType.Joined, _time.Now) { NodeAddress = member.Address.ToString() });
+                _gossip?.MembershipEventBuffer.Add(new MembershipEvent(member.Id, MembershipEventType.Joined, _time.Now, member.Incarnation) { NodeAddress = member.Address.ToString() });
             }
         }
 
         return Task.CompletedTask;
     }
 
-    public Task OnNodeLeft(string nodeId)
-        => OnNodeLeft(nodeId, addToEventBuffer: false);
+    public Task OnNodeLeft(string nodeId, long incarnation = 0)
+        => OnNodeLeft(nodeId, incarnation, addToEventBuffer: false);
 
-    protected Task OnNodeLeft(string nodeId, bool addToEventBuffer)
+    public Task OnNodeLeft(string nodeId)
+        => OnNodeLeft(nodeId, incarnation: 0);
+
+    protected Task OnNodeLeft(string nodeId, long incarnation, bool addToEventBuffer)
     {
         // Add other members only
         if (nodeId != _selfMember.Id)
@@ -242,13 +248,19 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
             var member = _otherMembers.SingleOrDefault(x => x.Id == nodeId);
             if (member != null)
             {
+                if (incarnation < member.Incarnation)
+                {
+                    _logger.LogDebug("Ignoring stale left/faulted event for node {NodeId} with incarnation {EventIncarnation}; current incarnation is {MemberIncarnation}", nodeId, incarnation, member.Incarnation);
+                    return Task.CompletedTask;
+                }
+
                 _logger.LogInformation("Node {NodeId} left at {NodeAddress}", nodeId, member.Address);
                 _otherMembers.Mutate(list => list.Remove(member));
 
                 if (addToEventBuffer)
                 {
                     // Notify the member faulted
-                    _gossip?.MembershipEventBuffer.Add(new MembershipEvent(member.Id, MembershipEventType.Left, _time.Now));
+                    _gossip?.MembershipEventBuffer.Add(new MembershipEvent(member.Id, MembershipEventType.Left, _time.Now, member.Incarnation));
                 }
 
                 _ = NotifyMemberLeft(member);
@@ -262,9 +274,9 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
         if (member.SwimStatus == SwimMemberStatus.Faulted)
         {
             // Notify the member faulted
-            _gossip?.MembershipEventBuffer.Add(new MembershipEvent(member.Id, MembershipEventType.Faulted, _time.Now));
+            _gossip?.MembershipEventBuffer.Add(new MembershipEvent(member.Id, MembershipEventType.Faulted, _time.Now, member.Incarnation));
 
-            _ = OnNodeLeft(member.Id);
+            _ = OnNodeLeft(member.Id, member.Incarnation);
         }
         else
         {
@@ -317,7 +329,7 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
         return Task.CompletedTask;
     }
 
-    private SwimMember EnsureNodeOnMemberlist(string nodeId, IAddress nodeAddress)
+    private SwimMember EnsureNodeOnMemberlist(string nodeId, IAddress nodeAddress, long incarnation = 0)
     {
         _logger.LogDebug("Ensuring node {NodeId}@{NodeAddress} is on the memberlist", nodeId, nodeAddress);
 
@@ -326,6 +338,14 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
             : _otherMembers.SingleOrDefault(x => x.Id == nodeId);
         if (member != null)
         {
+            if (incarnation < member.Incarnation)
+            {
+                _logger.LogDebug("Ignoring stale observation for node {NodeId} with incarnation {ObservedIncarnation}; current incarnation is {MemberIncarnation}", nodeId, incarnation, member.Incarnation);
+                return member;
+            }
+
+            member.ObserveIncarnation(incarnation);
+
             // Check if address changed
             if (member.OnObservedAddress(nodeAddress))
             {
@@ -340,7 +360,7 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
                 var existingMember = list.SingleOrDefault(x => x.Id == nodeId);
                 if (existingMember == null)
                 {
-                    existingMember = CreateMember(nodeId, nodeAddress);
+                    existingMember = CreateMember(nodeId, nodeAddress, incarnation);
                     list.Add(existingMember);
                     _logger.LogTrace("Added {Node} to the memberlist", existingMember);
                 }
@@ -380,6 +400,7 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
             periodSequenceNumber: m.PeriodSequenceNumber,
             targetAddress: targetNodeAddress,
             requestingAddress: senderAddress,
+            targetNodeId: m.NodeId,
             expiresAt: _time.Now.Add(_options.ProtocolPeriod.Multiply(3))); // Waiting 3 protocol period cycles should be more than enough
 
         _indirectPingRequests.Mutate(list =>
@@ -410,7 +431,11 @@ public class SwimClusterMembership : TaskLoop, IClusterMembership, IClusterContr
         }
 
         // Forward acks for PingReq (if any)
-        var matchedIndirectPingRequests = _indirectPingRequests.Where(x => x.TargetEndpoint.Equals(senderAddress) && x.PeriodSequenceNumber == m.PeriodSequenceNumber).ToList();
+        var matchedIndirectPingRequests = _indirectPingRequests
+            .Where(x => x.TargetEndpoint.Equals(senderAddress)
+                && x.TargetNodeId == m.NodeId
+                && x.PeriodSequenceNumber == m.PeriodSequenceNumber)
+            .ToList();
         if (matchedIndirectPingRequests.Count > 0)
         {
             _indirectPingRequests.Mutate(list =>

--- a/src/SlimCluster.Membership.Swim/SwimFailureDetector.cs
+++ b/src/SlimCluster.Membership.Swim/SwimFailureDetector.cs
@@ -88,6 +88,14 @@ public class SwimFailureDetector
 
     private Task OnPingTimeout()
     {
+        if (pingNode == null)
+        {
+            // in case this would have changed
+            return Task.CompletedTask;
+        }
+
+        pingNode.OnSuspicious();
+
         // get the active members only
         var activeMembers = ActiveMembers;
         if (activeMembers.Count == 0)
@@ -106,18 +114,14 @@ public class SwimFailureDetector
             activeMembers.RemoveAt(selectedMemberIndex);
         }
 
-        if (pingNode == null)
-        {
-            // in case this would have changed
-            return Task.CompletedTask;
-        }
-
-        var targetNodeAddress = pingNode.Address.ToString();
+        var targetNodeAddress = pingNode.Address.ToString() ?? string.Empty;
+        var targetNodeId = pingNode.Id;
 
         Task SendPingReq(SwimMember member)
         {
             var message = new PingReqMessage(_currentNode.Id)
             {
+                NodeId = targetNodeId,
                 NodeAddress = targetNodeAddress,
                 PeriodSequenceNumber = PeriodSequenceNumber
             };
@@ -135,7 +139,7 @@ public class SwimFailureDetector
         // Declare node that did not recieve an Ack for the Ping as Failed
         if (pingNode != null)
         {
-            if (pingNode.Status == SwimMemberStatus.Confirming)
+            if (pingNode.Status == SwimMemberStatus.Confirming || pingNode.Status == SwimMemberStatus.Suspicious)
             {
                 // When the node Ack did not arrive (via direct ping or via inderect ping-req) then declare this node as unhealty
                 pingNode.OnFaulted();
@@ -188,10 +192,16 @@ public class SwimFailureDetector
             {
                 _logger.LogDebug("Ack arrived too late from the node {NodeId}, period {PeriodSequenceNumber}, while the Ack message was for period {AckPeriodSequenceNumber}", m.NodeId, PeriodSequenceNumber, m.PeriodSequenceNumber);
             }
+            else if (pingNode == null || pingNode.Id != m.NodeId)
+            {
+                _logger.LogDebug("Ack arrived from node {NodeId}, but the current ping target is {PingNodeId}", m.NodeId, pingNode?.Id);
+            }
             else
             {
                 _logger.LogDebug("Ack arrived from the node {NodeId}, period {PeriodSequenceNumber}, node status {NodeStatus}", m.NodeId, PeriodSequenceNumber, node.Status);
                 node.OnActive(_time);
+                pingAckTimeout = null;
+                pingNode = null;
             }
         }
 

--- a/src/SlimCluster.Membership.Swim/SwimGossip.cs
+++ b/src/SlimCluster.Membership.Swim/SwimGossip.cs
@@ -60,13 +60,27 @@ public class SwimGossip
                     }
                     else
                     {
-                        await _membershipEventListener.OnNodeJoined(e.NodeId, remoteAddress.Parse(e.NodeAddress));
+                        if (_membershipEventListener is IIncarnationMembershipEventListener incarnationListener)
+                        {
+                            await incarnationListener.OnNodeJoined(e.NodeId, remoteAddress.Parse(e.NodeAddress), e.Incarnation);
+                        }
+                        else
+                        {
+                            await _membershipEventListener.OnNodeJoined(e.NodeId, remoteAddress.Parse(e.NodeAddress));
+                        }
                     }
                 }
                 if (e.Type == MembershipEventType.Left || e.Type == MembershipEventType.Faulted)
                 {
                     _logger.LogDebug("Event arrived that member {NodeId} left/faulted", e.NodeId);
-                    await _membershipEventListener.OnNodeLeft(e.NodeId);
+                    if (_membershipEventListener is IIncarnationMembershipEventListener incarnationListener)
+                    {
+                        await incarnationListener.OnNodeLeft(e.NodeId, e.Incarnation);
+                    }
+                    else
+                    {
+                        await _membershipEventListener.OnNodeLeft(e.NodeId);
+                    }
                 }
             }
         }

--- a/src/SlimCluster.Membership.Swim/SwimMember.cs
+++ b/src/SlimCluster.Membership.Swim/SwimMember.cs
@@ -13,6 +13,7 @@ public class SwimMember : AbstractNode, IMember, INode
     #endregion
 
     public SwimMemberStatus SwimStatus { get; protected set; }
+    public long Incarnation { get; protected set; }
 
     /// <summary>
     /// Point in time after which the Suspicious node will be declared as Confirm if no ACK is recieved.
@@ -28,7 +29,7 @@ public class SwimMember : AbstractNode, IMember, INode
 
     #endregion
 
-    public SwimMember(string id, IAddress address, DateTimeOffset joined, SwimMemberStatus status, Action<SwimMember>? notifyStatusChanged, ILogger<SwimMember> logger)
+    public SwimMember(string id, IAddress address, DateTimeOffset joined, SwimMemberStatus status, Action<SwimMember>? notifyStatusChanged, ILogger<SwimMember> logger, long incarnation = 0)
         : base(id)
     {
         _logger = logger;
@@ -36,8 +37,20 @@ public class SwimMember : AbstractNode, IMember, INode
 
         Address = address;
         SwimStatus = status;
+        Incarnation = incarnation;
         Joined = joined;
         LastSeen = joined;
+    }
+
+    public bool ObserveIncarnation(long incarnation)
+    {
+        if (incarnation <= Incarnation)
+        {
+            return false;
+        }
+
+        Incarnation = incarnation;
+        return true;
     }
 
     public void OnActive(ITime time)
@@ -80,7 +93,7 @@ public class SwimMember : AbstractNode, IMember, INode
 
     public void OnFaulted()
     {
-        if (Status == SwimMemberStatus.Confirming)
+        if (Status == SwimMemberStatus.Confirming || Status == SwimMemberStatus.Suspicious)
         {
             ChangeStatusTo(SwimMemberStatus.Faulted);
         }

--- a/src/SlimCluster.Membership.Swim/SwimMemberSelf.cs
+++ b/src/SlimCluster.Membership.Swim/SwimMemberSelf.cs
@@ -3,7 +3,7 @@
 public class SwimMemberSelf : SwimMember, ICurrentNode
 {
     public SwimMemberSelf(string id, IAddress address, ITime time, ILoggerFactory loggerFactory)
-        : base(id, address, time.Now, SwimMemberStatus.Active, notifyStatusChanged: null, loggerFactory.CreateLogger<SwimMember>())
+        : base(id, address, time.Now, SwimMemberStatus.Active, notifyStatusChanged: null, loggerFactory.CreateLogger<SwimMember>(), Math.Max(1, time.Now.UtcTicks))
     {
     }
 }

--- a/src/Tests/SlimCluster.Membership.Swim.Test/SwimClusterMembershipOptionsValidatorTests.cs
+++ b/src/Tests/SlimCluster.Membership.Swim.Test/SwimClusterMembershipOptionsValidatorTests.cs
@@ -1,0 +1,30 @@
+namespace SlimCluster.Membership.Swim.Tests;
+
+public class SwimClusterMembershipOptionsValidatorTests
+{
+    private readonly SwimClusterMembershipOptionsValidator _subject = new();
+
+    [Fact]
+    public void Given_DefaultOptions_When_Validate_Then_Succeeds()
+    {
+        var result = _subject.Validate(null, new SwimClusterMembershipOptions());
+
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Given_InvalidOptions_When_Validate_Then_Fails()
+    {
+        var result = _subject.Validate(null, new SwimClusterMembershipOptions
+        {
+            ProtocolPeriod = TimeSpan.FromSeconds(1),
+            PingAckTimeout = TimeSpan.FromSeconds(1),
+            FailureDetectionSubgroupSize = -1,
+            MembershipEventBufferCount = 0,
+            MembershipEventPiggybackCount = -1,
+        });
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().HaveCount(4);
+    }
+}

--- a/src/Tests/SlimCluster.Membership.Swim.Test/SwimFailureDetectorTests.cs
+++ b/src/Tests/SlimCluster.Membership.Swim.Test/SwimFailureDetectorTests.cs
@@ -165,6 +165,91 @@ public class SwimFailureDetectorTests
         pingTarget.SwimStatus.Should().Be(SwimMemberStatus.Faulted);
     }
 
+    [Fact]
+    public async Task Given_PingAckTimeout_When_NoAckArrives_Then_NodeMarkedSuspicious()
+    {
+        var pingTarget = MakeMember("target", "10.0.0.9:6000");
+        var subject = CreateSubject(new List<SwimMember> { pingTarget });
+
+        _messageSenderMock
+            .Setup(x => x.SendMessage(It.IsAny<SwimMessage>(), It.IsAny<IAddress>()))
+            .Returns(Task.CompletedTask);
+
+        var afterPeriod = _now.Add(_options.ProtocolPeriod).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterPeriod);
+        await subject.DoRun();
+
+        var afterAck = afterPeriod.Add(_options.PingAckTimeout).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterAck);
+        await subject.DoRun();
+
+        pingTarget.SwimStatus.Should().Be(SwimMemberStatus.Suspicious);
+    }
+
+    [Fact]
+    public async Task Given_CurrentProbeAckArrives_When_PingAckTimeoutPasses_Then_NoPingReqSent()
+    {
+        var pingTarget = MakeMember("target", "10.0.0.9:6000");
+        var subject = CreateSubject(new List<SwimMember> { pingTarget });
+
+        _messageSenderMock
+            .Setup(x => x.SendMessage(It.IsAny<SwimMessage>(), It.IsAny<IAddress>()))
+            .Returns(Task.CompletedTask);
+
+        var afterPeriod = _now.Add(_options.ProtocolPeriod).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterPeriod);
+        await subject.DoRun();
+
+        await subject.OnAckArrived(new AckMessage("target")
+        {
+            NodeId = "target",
+            PeriodSequenceNumber = subject.PeriodSequenceNumber,
+        }, pingTarget.Address);
+
+        var afterAck = afterPeriod.Add(_options.PingAckTimeout).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterAck);
+
+        _messageSenderMock.Invocations.Clear();
+        var idle = await subject.DoRun();
+
+        idle.Should().BeTrue();
+        pingTarget.SwimStatus.Should().Be(SwimMemberStatus.Active);
+        _messageSenderMock.Verify(
+            x => x.SendMessage(It.IsAny<PingReqMessage>(), It.IsAny<IAddress>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Given_AckForDifferentNode_When_AckArrives_Then_CurrentProbeStillTimesOut()
+    {
+        var pingTarget = MakeMember("target", "10.0.0.9:6000");
+        var other = MakeMember("other", "10.0.0.10:6000");
+        var subject = CreateSubject(new List<SwimMember> { pingTarget, other });
+
+        _messageSenderMock
+            .Setup(x => x.SendMessage(It.IsAny<SwimMessage>(), It.IsAny<IAddress>()))
+            .Returns(Task.CompletedTask);
+
+        var afterPeriod = _now.Add(_options.ProtocolPeriod).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterPeriod);
+        await subject.DoRun();
+
+        var currentTarget = new[] { pingTarget, other }.Single(x => x.SwimStatus == SwimMemberStatus.Confirming);
+        var otherNode = new[] { pingTarget, other }.Single(x => x.Id != currentTarget.Id);
+
+        await subject.OnAckArrived(new AckMessage(otherNode.Id)
+        {
+            NodeId = otherNode.Id,
+            PeriodSequenceNumber = subject.PeriodSequenceNumber,
+        }, otherNode.Address);
+
+        var afterAck = afterPeriod.Add(_options.PingAckTimeout).AddSeconds(1);
+        _timeMock.SetupGet(x => x.Now).Returns(afterAck);
+        await subject.DoRun();
+
+        currentTarget.SwimStatus.Should().Be(SwimMemberStatus.Suspicious);
+    }
+
     // -----------------------------------------------------------------------
     // DoRun: idle vs non-idle based on time
     // -----------------------------------------------------------------------

--- a/src/Tests/SlimCluster.Membership.Swim.Test/SwimGossipTests.cs
+++ b/src/Tests/SlimCluster.Membership.Swim.Test/SwimGossipTests.cs
@@ -7,6 +7,7 @@ public class SwimGossipTests
     private readonly DateTimeOffset _now;
     private readonly SwimClusterMembershipOptions _options;
     private readonly Mock<IMembershipEventListener> _membershipEventListenerMock;
+    private readonly Mock<IIncarnationMembershipEventListener> _incarnationMembershipEventListenerMock;
     private readonly Mock<IMembershipEventBuffer> _membershipEventBufferMock;
     private readonly SwimGossip subject;
 
@@ -14,7 +15,8 @@ public class SwimGossipTests
     {
         _now = DateTimeOffset.Parse("2022-06-13");
         _options = new SwimClusterMembershipOptions();
-        _membershipEventListenerMock = new Mock<IMembershipEventListener>();
+        _incarnationMembershipEventListenerMock = new Mock<IIncarnationMembershipEventListener>();
+        _membershipEventListenerMock = _incarnationMembershipEventListenerMock.As<IMembershipEventListener>();
         _membershipEventBufferMock = new Mock<IMembershipEventBuffer>();
 
         subject = new SwimGossip(XUnitLogger.CreateLogger<SwimGossip>(testOutputHelper), _options, _membershipEventListenerMock.Object, _membershipEventBufferMock.Object);
@@ -47,11 +49,11 @@ public class SwimGossipTests
         {
             if (eventType == Messages.MembershipEventType.Joined)
             {
-                _membershipEventListenerMock.Verify(x => x.OnNodeJoined(e1.NodeId, It.Is<IAddress>(ip => ip.ToString() == e1.NodeAddress)), Times.Once);
+                _incarnationMembershipEventListenerMock.Verify(x => x.OnNodeJoined(e1.NodeId, It.Is<IAddress>(ip => ip.ToString() == e1.NodeAddress), e1.Incarnation), Times.Once);
             }
             if (eventType == Messages.MembershipEventType.Faulted | eventType == Messages.MembershipEventType.Left)
             {
-                _membershipEventListenerMock.Verify(x => x.OnNodeLeft(e1.NodeId), Times.Once);
+                _incarnationMembershipEventListenerMock.Verify(x => x.OnNodeLeft(e1.NodeId, e1.Incarnation), Times.Once);
             }
         }
         _membershipEventListenerMock.VerifyNoOtherCalls();

--- a/src/Tests/SlimCluster.Membership.Swim.Test/SwimMembershipEventBufferTests.cs
+++ b/src/Tests/SlimCluster.Membership.Swim.Test/SwimMembershipEventBufferTests.cs
@@ -95,6 +95,14 @@ public class SwimMembershipEventBufferTests
     }
 
     [Fact]
+    public void Given_ZeroCapacity_When_CreateBuffer_Then_Throws()
+    {
+        var act = () => new MembershipEventBuffer(0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
     public void Given_FullBuffer_When_AddNewEvent_Then_ReplacesHighestUsedEntry()
     {
         // arrange
@@ -124,8 +132,8 @@ public class SwimMembershipEventBufferTests
     }
 
     /// <summary>
-    /// When two events arrive for the same node, the one with the newer timestamp wins.
-    /// A duplicate or older event should be ignored (returns false).
+    /// When two events arrive for the same node, the one with the newer incarnation wins.
+    /// When incarnations are equal, the newer timestamp wins.
     /// Parameters: (firstType, firstOffsetMinutes, secondType, secondOffsetMinutes, expectedAddedResult, expectedSurvivingType)
     /// </summary>
     [Theory]
@@ -150,6 +158,32 @@ public class SwimMembershipEventBufferTests
         var events = subject.GetNextEvents(10);
         events.Should().HaveCount(1);
         events.Single().Type.Should().Be(expectedSurvivingType);
+    }
+
+    [Fact]
+    public void Given_EventsForSameNode_When_HigherIncarnationHasOlderTimestamp_Then_HigherIncarnationWins()
+    {
+        var subject = new MembershipEventBuffer(10);
+
+        subject.Add(new Messages.MembershipEvent("node1", Messages.MembershipEventType.Joined, _now.AddMinutes(10), incarnation: 1));
+
+        var added = subject.Add(new Messages.MembershipEvent("node1", Messages.MembershipEventType.Faulted, _now, incarnation: 2));
+
+        added.Should().BeTrue();
+        subject.GetNextEvents(10).Single().Type.Should().Be(Messages.MembershipEventType.Faulted);
+    }
+
+    [Fact]
+    public void Given_EventsForSameNode_When_LowerIncarnationHasNewerTimestamp_Then_LowerIncarnationIgnored()
+    {
+        var subject = new MembershipEventBuffer(10);
+
+        subject.Add(new Messages.MembershipEvent("node1", Messages.MembershipEventType.Faulted, _now, incarnation: 2));
+
+        var added = subject.Add(new Messages.MembershipEvent("node1", Messages.MembershipEventType.Joined, _now.AddMinutes(10), incarnation: 1));
+
+        added.Should().BeFalse();
+        subject.GetNextEvents(10).Single().Type.Should().Be(Messages.MembershipEventType.Faulted);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add incarnation-aware SWIM membership events and direct join/left messages so newer observations supersede stale gossip
- tighten failure detection by moving timed-out probes to Suspicious, correlating ACKs with the current probe target, and including target node ids in PingReq forwarding
- validate SWIM options at startup and document the new protocol behavior
- add repo guidance to use feature/ branch names

## Tests
- dotnet test src\Tests\SlimCluster.Membership.Swim.Test\SlimCluster.Membership.Swim.Test.csproj -v minimal -m:1 -nodeReuse:false
- dotnet test src\SlimCluster.slnx -v minimal -m:1 -nodeReuse:false