### PR TITLE
Improve Raft safety and shutdown handling

### DIFF
--- a/src/Samples/SlimCluster.Samples.Service/State/StateMachine/CounterStateMachine.cs
+++ b/src/Samples/SlimCluster.Samples.Service/State/StateMachine/CounterStateMachine.cs
@@ -45,4 +45,7 @@ public class CounterStateMachine : IStateMachine, ICounterState
 
     // For now we don't support snapshotting
     public Task Snapshot() => throw new NotImplementedException();
+
+    // For now we don't support snapshotting
+    public Task InstallSnapshot(byte[] snapshot, int lastIncludedIndex, int lastIncludedTerm) => throw new NotImplementedException();
 }

--- a/src/Samples/SlimCluster.Samples.Service/State/StateMachine/CounterStateMachine.cs
+++ b/src/Samples/SlimCluster.Samples.Service/State/StateMachine/CounterStateMachine.cs
@@ -44,7 +44,7 @@ public class CounterStateMachine : IStateMachine, ICounterState
     public Task Restore() => throw new NotImplementedException();
 
     // For now we don't support snapshotting
-    public Task Snapshot() => throw new NotImplementedException();
+    public Task<byte[]> Snapshot() => throw new NotImplementedException();
 
     // For now we don't support snapshotting
     public Task InstallSnapshot(byte[] snapshot, int lastIncludedIndex, int lastIncludedTerm) => throw new NotImplementedException();

--- a/src/Samples/SlimCluster.Samples.Service/State/StateMachine/CounterStateMachine.cs
+++ b/src/Samples/SlimCluster.Samples.Service/State/StateMachine/CounterStateMachine.cs
@@ -1,5 +1,7 @@
 ﻿namespace SlimCluster.Samples.ConsoleApp.State.StateMachine;
 
+using System.Text.Json;
+
 using SlimCluster.Consensus.Raft;
 using SlimCluster.Samples.ConsoleApp.State.Logs;
 
@@ -8,6 +10,8 @@ using SlimCluster.Samples.ConsoleApp.State.Logs;
 /// </summary>
 public class CounterStateMachine : IStateMachine, ICounterState
 {
+    private sealed record CounterSnapshot(int Index, int Counter);
+
     private int _index = 0;
     private int _counter = 0;
 
@@ -32,7 +36,7 @@ public class CounterStateMachine : IStateMachine, ICounterState
             IncrementCounterCommand => ++_counter,
             DecrementCounterCommand => --_counter,
             ResetCounterCommand => _counter = 0,
-            _ => throw new NotImplementedException($"The command type ${command?.GetType().Name} is not supported")
+            _ => throw new NotSupportedException($"The command type ${command?.GetType().Name} is not supported")
         };
 
         _index = index;
@@ -40,12 +44,27 @@ public class CounterStateMachine : IStateMachine, ICounterState
         return Task.FromResult<object?>(result);
     }
 
-    // For now we don't support snapshotting
-    public Task Restore() => throw new NotImplementedException();
+    public Task Restore() => Task.CompletedTask;
 
-    // For now we don't support snapshotting
-    public Task<byte[]> Snapshot() => throw new NotImplementedException();
+    public Task<byte[]> Snapshot()
+    {
+        var snapshot = new CounterSnapshot(_index, _counter);
+        return Task.FromResult(JsonSerializer.SerializeToUtf8Bytes(snapshot));
+    }
 
-    // For now we don't support snapshotting
-    public Task InstallSnapshot(byte[] snapshot, int lastIncludedIndex, int lastIncludedTerm) => throw new NotImplementedException();
+    public Task InstallSnapshot(byte[] snapshot, int lastIncludedIndex, int lastIncludedTerm)
+    {
+        var state = JsonSerializer.Deserialize<CounterSnapshot>(snapshot)
+            ?? throw new InvalidOperationException("The counter snapshot payload is empty or invalid.");
+
+        if (state.Index != lastIncludedIndex)
+        {
+            throw new InvalidOperationException("The counter snapshot index does not match the Raft snapshot metadata.");
+        }
+
+        _index = state.Index;
+        _counter = state.Counter;
+
+        return Task.CompletedTask;
+    }
 }

--- a/src/SlimCluster.Consensus.Raft/Configuration/RaftConsensusOptions.cs
+++ b/src/SlimCluster.Consensus.Raft/Configuration/RaftConsensusOptions.cs
@@ -37,4 +37,14 @@ public class RaftConsensusOptions
     /// The timeout for a leader to process the request.
     /// </summary>
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Maximum number of snapshot bytes sent in a single InstallSnapshot request.
+    /// </summary>
+    public int SnapshotChunkSize { get; set; } = 64 * 1024;
+
+    /// <summary>
+    /// Maximum number of snapshot bytes a follower will buffer while installing a snapshot.
+    /// </summary>
+    public int MaxInstallSnapshotBytes { get; set; } = 64 * 1024 * 1024;
 }

--- a/src/SlimCluster.Consensus.Raft/Logs/ILogRepository.cs
+++ b/src/SlimCluster.Consensus.Raft/Logs/ILogRepository.cs
@@ -20,6 +20,7 @@ public interface ILogRepository
     Task Commit(int index);
     int GetTermAtIndex(int index);
     Task EraseBefore(int index);
+    Task InstallSnapshot(LogIndex lastIncludedIndex);
     Task<IReadOnlyList<LogEntry>> GetLogsAtIndex(int index, int count);
 }
 

--- a/src/SlimCluster.Consensus.Raft/Logs/ILogRepository.cs
+++ b/src/SlimCluster.Consensus.Raft/Logs/ILogRepository.cs
@@ -3,6 +3,8 @@
 public interface ILogRepository
 {
     LogIndex LastIndex { get; }
+    LogIndex LastCompactedIndex { get; }
+    int FirstAvailableIndex { get; }
     int CommitedIndex { get; }
     Task Append(IEnumerable<LogEntry> logs);
     /// <summary>

--- a/src/SlimCluster.Consensus.Raft/Logs/InMemoryLogRepository.cs
+++ b/src/SlimCluster.Consensus.Raft/Logs/InMemoryLogRepository.cs
@@ -6,6 +6,7 @@ public class InMemoryLogRepository : ILogRepository
 {
     private LogIndex _lastIndex = new(0, 0);
     private int _commitedIndex = 0;
+    private LogIndex _lastCompactedIndex = new(0, 0);
 
     private int _logsStartIndex = 1;
     private readonly LinkedList<LogEntry> _logs = new();
@@ -15,6 +16,16 @@ public class InMemoryLogRepository : ILogRepository
 
     public virtual int GetTermAtIndex(int index)
     {
+        if (index == 0)
+        {
+            return 0;
+        }
+
+        if (index == _lastCompactedIndex.Index)
+        {
+            return _lastCompactedIndex.Term;
+        }
+
         var log = _logs.ElementAtOrDefault(index - _logsStartIndex)
             ?? throw new ArgumentOutOfRangeException(nameof(index), index, null);
 
@@ -78,15 +89,41 @@ public class InMemoryLogRepository : ILogRepository
 
     public Task EraseBefore(int index)
     {
-        if (index > _lastIndex.Index && _logsStartIndex > index)
+        if (index > _lastIndex.Index + 1 || index < _logsStartIndex)
         {
             throw new ArgumentOutOfRangeException(nameof(index), index, null);
         }
 
         while (_logsStartIndex < index)
         {
+            _lastCompactedIndex = new LogIndex(_logsStartIndex, _logs.First!.Value.Term);
             _logs.RemoveFirst();
             _logsStartIndex++;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public virtual Task InstallSnapshot(LogIndex lastIncludedIndex)
+    {
+        if (lastIncludedIndex.Index < _commitedIndex)
+        {
+            return Task.CompletedTask;
+        }
+
+        while (_logs.Count > 0 && _logsStartIndex <= lastIncludedIndex.Index)
+        {
+            _logs.RemoveFirst();
+            _logsStartIndex++;
+        }
+
+        _lastCompactedIndex = lastIncludedIndex;
+        _commitedIndex = lastIncludedIndex.Index;
+        if (_lastIndex.Index < lastIncludedIndex.Index)
+        {
+            _lastIndex = lastIncludedIndex;
+            _logsStartIndex = lastIncludedIndex.Index + 1;
+            _logs.Clear();
         }
 
         return Task.CompletedTask;

--- a/src/SlimCluster.Consensus.Raft/Logs/InMemoryLogRepository.cs
+++ b/src/SlimCluster.Consensus.Raft/Logs/InMemoryLogRepository.cs
@@ -12,6 +12,8 @@ public class InMemoryLogRepository : ILogRepository
     private readonly LinkedList<LogEntry> _logs = new();
 
     public virtual LogIndex LastIndex => _lastIndex;
+    public virtual LogIndex LastCompactedIndex => _lastCompactedIndex;
+    public virtual int FirstAvailableIndex => _logsStartIndex;
     public virtual int CommitedIndex => _commitedIndex;
 
     public virtual int GetTermAtIndex(int index)
@@ -64,7 +66,21 @@ public class InMemoryLogRepository : ILogRepository
                 throw new ArgumentOutOfRangeException(nameof(entry.Index), entry.Index, null);
             }
 
-            // Remove all starting at index
+            if (entry.Index <= _lastIndex.Index)
+            {
+                var existingTerm = GetTermAtIndex(entry.Index);
+                if (existingTerm == entry.Term)
+                {
+                    continue;
+                }
+
+                if (entry.Index <= _commitedIndex)
+                {
+                    throw new InvalidOperationException($"Cannot overwrite committed log entry at index {entry.Index}.");
+                }
+            }
+
+            // Remove conflicting uncommitted entries starting at index.
             while (_logs.Count + _logsStartIndex > entry.Index)
             {
                 _logs.RemoveLast();
@@ -119,7 +135,7 @@ public class InMemoryLogRepository : ILogRepository
 
         _lastCompactedIndex = lastIncludedIndex;
         _commitedIndex = lastIncludedIndex.Index;
-        if (_lastIndex.Index < lastIncludedIndex.Index)
+        if (_lastIndex.Index <= lastIncludedIndex.Index)
         {
             _lastIndex = lastIncludedIndex;
             _logsStartIndex = lastIncludedIndex.Index + 1;

--- a/src/SlimCluster.Consensus.Raft/Messages/InstallSnapshotRequest.cs
+++ b/src/SlimCluster.Consensus.Raft/Messages/InstallSnapshotRequest.cs
@@ -4,6 +4,7 @@ public class InstallSnapshotRequest : RaftMessage, IHasTerm, IRequest<InstallSna
 {
     public int Term { get; set; }
     public string? LeaderId { get; set; }
+    public Guid SnapshotId { get; set; }
     public int LastIncludedIndex { get; set; }
     public int LastIncludedTerm { get; set; }
     public int Offset { get; set; }

--- a/src/SlimCluster.Consensus.Raft/Messages/InstallSnapshotRequest.cs
+++ b/src/SlimCluster.Consensus.Raft/Messages/InstallSnapshotRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace SlimCluster.Consensus.Raft;
 
-public class InstallSnapshotRequest : RaftMessage
+public class InstallSnapshotRequest : RaftMessage, IHasTerm, IRequest<InstallSnapshotResponse>
 {
     public int Term { get; set; }
     public string? LeaderId { get; set; }

--- a/src/SlimCluster.Consensus.Raft/Messages/InstallSnapshotResponse.cs
+++ b/src/SlimCluster.Consensus.Raft/Messages/InstallSnapshotResponse.cs
@@ -3,6 +3,7 @@
 public class InstallSnapshotResponse : RaftResponse
 {
     public int Term { get; set; }
+    public bool Success { get; set; }
 
     protected InstallSnapshotResponse()
     {

--- a/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
+++ b/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
@@ -173,7 +173,9 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
 
         var majorityMatchIndex = orderedMatchIndexes.FirstOrDefault(matchIndex =>
         {
-            return orderedMatchIndexes.Count(x => x >= matchIndex) > majorityCount;
+            return matchIndex > _logRepository.CommitedIndex
+                && _logRepository.GetTermAtIndex(matchIndex) == Term
+                && orderedMatchIndexes.Count(x => x >= matchIndex) > majorityCount;
         });
 
         return Math.Max(majorityMatchIndex, _logRepository.CommitedIndex);
@@ -234,7 +236,7 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
 
                 _logger.LogInformation("{Node}: Follower log does not match at MatchIndex = {MatchIndex}", followerNode, followerReplicationState.MatchIndex);
                 // logs dont match for the specified index, will retry on next loop run with prev index
-                followerReplicationState.NextIndex--;
+                followerReplicationState.NextIndex = Math.Max(1, followerReplicationState.NextIndex - 1);
             }
         }
         catch (OperationCanceledException)
@@ -272,7 +274,7 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
 
         var requestTimer = Stopwatch.StartNew();
 
-        var tcs = new TaskCompletionSource<object?>();
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         _pendingCommandResults.TryAdd(commandIndex, tcs);
         try
         {

--- a/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
+++ b/src/SlimCluster.Consensus.Raft/RaftLeaderState.cs
@@ -73,6 +73,13 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
         ReplicationStateByNode = new Dictionary<string, FollowerReplicatonState>();
     }
 
+    protected override async Task OnStarting()
+    {
+        await base.OnStarting();
+
+        await _logRepository.Append(Term, Array.Empty<byte>()).ConfigureAwait(false);
+    }
+
     protected override async Task<bool> OnLoopRun(CancellationToken token)
     {
         var tasks = new List<Task>();
@@ -96,7 +103,9 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
 
             if (sendNewLogEntries || sendPing)
             {
-                var task = ReplicateLogWithFollower(lastIndex, followerReplicationState, member.Node, skipEntries: sendFirstPing, token);
+                var task = followerReplicationState.NextIndex < _logRepository.FirstAvailableIndex
+                    ? InstallSnapshotOnFollower(followerReplicationState, member.Node, token)
+                    : ReplicateLogWithFollower(lastIndex, followerReplicationState, member.Node, skipEntries: sendFirstPing, token);
                 tasks.Add(task);
             }
         }
@@ -161,7 +170,7 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
 
     private int FindMajorityReplicatedIndex()
     {
-        var majorityCount = _options.NodeCount / 2;
+        var majorityCount = (_clusterMembership.OtherMembers.Count + 1) / 2;
 
         // Include the leader's own match index (its last log index) alongside followers.
         // ToDo: Do not take into account inactive members
@@ -246,6 +255,54 @@ public class RaftLeaderState : TaskLoop, IRaftClientRequestHandler, IDurableComp
 
             // The response did not arrive, account for the wait time we already lost to not keep on calling the possibly failed follower
             followerReplicationState.LastAppendRequest = _time.Now;
+        }
+    }
+
+    private async Task InstallSnapshotOnFollower(FollowerReplicatonState followerReplicationState, INode followerNode, CancellationToken token)
+    {
+        var snapshot = await _stateMachine.Snapshot().ConfigureAwait(false);
+        var snapshotId = Guid.NewGuid();
+        var offset = 0;
+
+        while (offset < snapshot.Length || offset == 0)
+        {
+            token.ThrowIfCancellationRequested();
+
+            var count = Math.Min(Math.Max(1, _options.SnapshotChunkSize), snapshot.Length - offset);
+            var done = offset + count >= snapshot.Length;
+            var req = new InstallSnapshotRequest
+            {
+                Term = Term,
+                LeaderId = _clusterMembership.SelfMember.Node.Id,
+                SnapshotId = snapshotId,
+                LastIncludedIndex = _logRepository.LastCompactedIndex.Index,
+                LastIncludedTerm = _logRepository.LastCompactedIndex.Term,
+                Offset = offset,
+                Data = count > 0 ? snapshot.Skip(offset).Take(count).ToArray() : Array.Empty<byte>(),
+                Done = done
+            };
+
+            var resp = await _messageSender.SendRequest(req, followerNode.Address, timeout: _options.LeaderPingInterval).ConfigureAwait(false);
+            followerReplicationState.LastAppendRequest = _time.Now;
+
+            if (resp.Term > Term)
+            {
+                await _onNewerTermDiscovered(resp.Term, followerNode).ConfigureAwait(false);
+                return;
+            }
+
+            if (!resp.Success)
+            {
+                return;
+            }
+
+            offset += count;
+            if (done)
+            {
+                followerReplicationState.MatchIndex = req.LastIncludedIndex;
+                followerReplicationState.NextIndex = req.LastIncludedIndex + 1;
+                return;
+            }
         }
     }
 

--- a/src/SlimCluster.Consensus.Raft/RaftNode.cs
+++ b/src/SlimCluster.Consensus.Raft/RaftNode.cs
@@ -47,6 +47,10 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
     private RaftCandidateState? _candidateState;
     private RaftFollowerState? _followerState;
     private MemoryStream? _installingSnapshot;
+    private Guid? _installingSnapshotId;
+    private string? _installingSnapshotLeaderId;
+    private int _installingSnapshotLastIncludedIndex;
+    private int _installingSnapshotLastIncludedTerm;
 
     private readonly ConcurrentQueue<(RaftMessage Message, IAddress Address)> _messages = new();
 
@@ -163,6 +167,18 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
         _candidateState = null;
 
         _followerState = null;
+
+        ClearInstallingSnapshot();
+    }
+
+    private void ClearInstallingSnapshot()
+    {
+        _installingSnapshot?.Dispose();
+        _installingSnapshot = null;
+        _installingSnapshotId = null;
+        _installingSnapshotLeaderId = null;
+        _installingSnapshotLastIncludedIndex = 0;
+        _installingSnapshotLastIncludedTerm = 0;
     }
 
     protected async Task BecomeLeader()
@@ -220,6 +236,7 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
                     // Save who we given the vote to
                     _votedFor = node.Id;
                     await PersistPersistentState();
+                    _followerState?.OnLeaderMessage(_followerState.Leader);
                 }
             }
         }
@@ -253,9 +270,10 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
                 _candidateState!.AddVote(node.Id);
 
                 // If majority votes, then claim leadership
-                if (_candidateState!.RecivedVotesFrom.Count > _options.NodeCount / 2)
+                var nodeCount = _clusterMembership.OtherMembers.Count + 1;
+                if (_candidateState!.RecivedVotesFrom.Count > nodeCount / 2)
                 {
-                    _logger.LogInformation("Recieved majority of votes {VoteCount} from cluster of {NodeCount} in term {Term}", _candidateState!.RecivedVotesFrom.Count, _options.NodeCount, _currentTerm);
+                    _logger.LogInformation("Recieved majority of votes {VoteCount} from cluster of {NodeCount} in term {Term}", _candidateState!.RecivedVotesFrom.Count, nodeCount, _currentTerm);
 
                     // clear who was voted for
                     _votedFor = null;
@@ -322,7 +340,16 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
 
         if (r.Entries != null && r.Entries.Count > 0)
         {
-            await _logRepository.Append(r.Entries);
+            try
+            {
+                await _logRepository.Append(r.Entries);
+            }
+            catch (InvalidOperationException e)
+            {
+                _logger.LogWarning(e, "Rejecting {Message} because it conflicts with committed log entries", r);
+                await SendAppendEntriesResponse(r, node, success: false);
+                return;
+            }
         }
 
         // Confirm all was good
@@ -372,11 +399,22 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
 
         if (r.Offset == 0)
         {
-            _installingSnapshot?.Dispose();
+            ClearInstallingSnapshot();
             _installingSnapshot = new MemoryStream();
+            _installingSnapshotId = r.SnapshotId;
+            _installingSnapshotLeaderId = r.LeaderId;
+            _installingSnapshotLastIncludedIndex = r.LastIncludedIndex;
+            _installingSnapshotLastIncludedTerm = r.LastIncludedTerm;
         }
 
-        if (_installingSnapshot == null || _installingSnapshot.Length != r.Offset)
+        var dataLength = r.Data?.Length ?? 0;
+        if (_installingSnapshot == null
+            || _installingSnapshotId != r.SnapshotId
+            || _installingSnapshotLeaderId != r.LeaderId
+            || _installingSnapshotLastIncludedIndex != r.LastIncludedIndex
+            || _installingSnapshotLastIncludedTerm != r.LastIncludedTerm
+            || _installingSnapshot.Length != r.Offset
+            || _installingSnapshot.Length + dataLength > _options.MaxInstallSnapshotBytes)
         {
             await SendInstallSnapshotResponse(r, node, success: false);
             return;
@@ -390,8 +428,7 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
         if (r.Done)
         {
             var snapshotBytes = _installingSnapshot.ToArray();
-            _installingSnapshot.Dispose();
-            _installingSnapshot = null;
+            ClearInstallingSnapshot();
 
             await _stateMachine.InstallSnapshot(snapshotBytes, r.LastIncludedIndex, r.LastIncludedTerm);
             await _logRepository.InstallSnapshot(new LogIndex(r.LastIncludedIndex, r.LastIncludedTerm));

--- a/src/SlimCluster.Consensus.Raft/RaftNode.cs
+++ b/src/SlimCluster.Consensus.Raft/RaftNode.cs
@@ -46,6 +46,7 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
     private RaftLeaderState? _leaderState;
     private RaftCandidateState? _candidateState;
     private RaftFollowerState? _followerState;
+    private MemoryStream? _installingSnapshot;
 
     private readonly ConcurrentQueue<(RaftMessage Message, IAddress Address)> _messages = new();
 
@@ -130,6 +131,7 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
         // vote for self
         _votedFor = _clusterMembership.SelfMember.Node.Id;
         _candidateState.AddVote(_votedFor);
+        await PersistPersistentState();
 
         // request votes from each other node
         var lastIndex = _logRepository.LastIndex;
@@ -145,6 +147,7 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
         await ClearPreviousState();
 
         UpdateTerm(term);
+        await PersistPersistentState();
 
         _followerState = new RaftFollowerState(_loggerFactory.CreateLogger<RaftFollowerState>(), _options, _time, _currentTerm, null);
     }
@@ -216,6 +219,7 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
                     resp.VoteGranted = true;
                     // Save who we given the vote to
                     _votedFor = node.Id;
+                    await PersistPersistentState();
                 }
             }
         }
@@ -255,6 +259,7 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
 
                     // clear who was voted for
                     _votedFor = null;
+                    await PersistPersistentState();
 
                     await BecomeLeader();
                 }
@@ -272,6 +277,12 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
     private Task SendAppendEntriesResponse(AppendEntriesRequest r, INode node, bool success)
     {
         var resp = new AppendEntriesResponse(r) { Term = _currentTerm, Success = success };
+        return _messageSender.SendMessage(resp, node.Address);
+    }
+
+    private Task SendInstallSnapshotResponse(InstallSnapshotRequest r, INode node, bool success)
+    {
+        var resp = new InstallSnapshotResponse(r) { Term = _currentTerm, Success = success };
         return _messageSender.SendMessage(resp, node.Address);
     }
 
@@ -332,10 +343,73 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
         }
     }
 
+    protected async Task OnInstallSnapshotRequest(InstallSnapshotRequest r, INode node)
+    {
+        _logger.LogTrace("Handling {Message} from {Node}", r, node);
+
+        if (r.Term > _currentTerm)
+        {
+            await OnNewerTermDiscovered(r.Term, node);
+        }
+
+        if (r.Term < _currentTerm)
+        {
+            await SendInstallSnapshotResponse(r, node, success: false);
+            return;
+        }
+
+        if (Status != RaftNodeStatus.Follower)
+        {
+            await BecomeFollower(r.Term);
+        }
+        _followerState?.OnLeaderMessage(node);
+
+        if (r.LastIncludedIndex <= _logRepository.CommitedIndex)
+        {
+            await SendInstallSnapshotResponse(r, node, success: true);
+            return;
+        }
+
+        if (r.Offset == 0)
+        {
+            _installingSnapshot?.Dispose();
+            _installingSnapshot = new MemoryStream();
+        }
+
+        if (_installingSnapshot == null || _installingSnapshot.Length != r.Offset)
+        {
+            await SendInstallSnapshotResponse(r, node, success: false);
+            return;
+        }
+
+        if (r.Data != null)
+        {
+            await _installingSnapshot.WriteAsync(r.Data);
+        }
+
+        if (r.Done)
+        {
+            var snapshotBytes = _installingSnapshot.ToArray();
+            _installingSnapshot.Dispose();
+            _installingSnapshot = null;
+
+            await _stateMachine.InstallSnapshot(snapshotBytes, r.LastIncludedIndex, r.LastIncludedTerm);
+            await _logRepository.InstallSnapshot(new LogIndex(r.LastIncludedIndex, r.LastIncludedTerm));
+        }
+
+        await SendInstallSnapshotResponse(r, node, success: true);
+    }
+
     private void UpdateTerm(int term)
     {
         _currentTerm = term;
         _votedFor = null;
+    }
+
+    private Task PersistPersistentState()
+    {
+        var persistenceService = _serviceProvider.GetService<IClusterPersistenceService>();
+        return persistenceService?.Persist(CancellationToken.None) ?? Task.CompletedTask;
     }
 
     protected override async Task<bool> OnLoopRun(CancellationToken token)
@@ -357,6 +431,7 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
                     RequestVoteRequest r => OnRequestVoteRequest(r, node),
                     RequestVoteResponse r => OnRequestVoteResponse(r, node),
                     AppendEntriesRequest r => OnAppendEntriesRequest(r, node),
+                    InstallSnapshotRequest r => OnInstallSnapshotRequest(r, node),
                     _ => null
                 };
                 if (task != null)
@@ -422,12 +497,17 @@ public class RaftNode : TaskLoop, IMessageArrivedHandler, IAsyncDisposable, IDur
 
         _votedFor = state.Get<string?>("votedFor");
         _currentTerm = state.Get<int>("currentTerm");
-        Status = RaftNodeStatus.FromId(state.Get<Guid>("statusId"));
+        var restoredStatus = RaftNodeStatus.FromId(state.Get<Guid>("statusId"));
 
-        var leaderState = state.SubComponent("Leader");
-        if (leaderState != null)
+        ClearPreviousState().GetAwaiter().GetResult();
+        if (restoredStatus == RaftNodeStatus.Unknown)
         {
-            _leaderState?.OnStateRestore(leaderState);
+            Status = RaftNodeStatus.Unknown;
+        }
+        else
+        {
+            Status = RaftNodeStatus.Follower;
+            _followerState = new RaftFollowerState(_loggerFactory.CreateLogger<RaftFollowerState>(), _options, _time, _currentTerm, null);
         }
     }
 

--- a/src/SlimCluster.Consensus.Raft/StateMachine/IStateMachine.cs
+++ b/src/SlimCluster.Consensus.Raft/StateMachine/IStateMachine.cs
@@ -25,4 +25,9 @@ public interface IStateMachine
     /// </summary>
     /// <returns></returns>
     Task Restore();
+
+    /// <summary>
+    /// Installs a snapshot received from the Raft leader.
+    /// </summary>
+    Task InstallSnapshot(byte[] snapshot, int lastIncludedIndex, int lastIncludedTerm);
 }

--- a/src/SlimCluster.Consensus.Raft/StateMachine/IStateMachine.cs
+++ b/src/SlimCluster.Consensus.Raft/StateMachine/IStateMachine.cs
@@ -15,10 +15,9 @@ public interface IStateMachine
     Task<object?> Apply(object command, int index);
 
     /// <summary>
-    /// Take a snapshot
+    /// Takes a snapshot and returns the payload that can be sent to followers.
     /// </summary>
-    /// <returns></returns>
-    Task Snapshot();
+    Task<byte[]> Snapshot();
 
     /// <summary>
     /// Restores state machine from persisted snapshot

--- a/src/SlimCluster.Consensus.Raft/StateMachine/StateMachineExtensions.cs
+++ b/src/SlimCluster.Consensus.Raft/StateMachine/StateMachineExtensions.cs
@@ -7,6 +7,13 @@ public static class StateMachineExtensions
 {
     public static async Task<object?> Apply(this IStateMachine stateMachine, ILogRepository logRepository, byte[] logEntry, int logIndex, ILogger logger, ISerializer logSerializer)
     {
+        if (logEntry.Length == 0)
+        {
+            logger.LogDebug("Committing no-op log at index {LogIndex}", logIndex);
+            await logRepository.Commit(logIndex).ConfigureAwait(false);
+            return null;
+        }
+
         logger.LogTrace("Deserializing log at index {LogIndex}", logIndex);
         var command = logSerializer.Deserialize(logEntry);
         logger.LogDebug("Applying log at index {LogIndex}", logIndex);

--- a/src/SlimCluster.Host/Common/TaskLoop.cs
+++ b/src/SlimCluster.Host/Common/TaskLoop.cs
@@ -12,6 +12,7 @@ public abstract class TaskLoop
     private bool _isStopping = false;
 
     public bool IsStarted => _isStarted;
+    protected virtual TimeSpan StopTimeout => TimeSpan.FromSeconds(5);
 
     protected TaskLoop(ILogger logger, TimeSpan idleLoopDelay)
     {
@@ -63,7 +64,15 @@ public abstract class TaskLoop
 
                 if (_loopTask != null)
                 {
-                    await _loopTask;
+                    var completedTask = await Task.WhenAny(_loopTask, Task.Delay(StopTimeout));
+                    if (completedTask == _loopTask)
+                    {
+                        await _loopTask;
+                    }
+                    else
+                    {
+                        _logger.LogError("Task loop did not stop within {StopTimeout}", StopTimeout);
+                    }
                     _loopTask = null;
                 }
 
@@ -95,8 +104,12 @@ public abstract class TaskLoop
                     var idleRun = await OnLoopRun(_loopCts.Token).ConfigureAwait(false);
                     if (idleRun)
                     {
-                        await Task.Delay(_idleLoopDelay).ConfigureAwait(false);
+                        await Task.Delay(_idleLoopDelay, _loopCts.Token).ConfigureAwait(false);
                     }
+                }
+                catch (OperationCanceledException) when (_loopCts?.IsCancellationRequested == true)
+                {
+                    break;
                 }
                 catch (Exception e)
                 {

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/InMemoryLogRepositoryTests.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/InMemoryLogRepositoryTests.cs
@@ -99,4 +99,62 @@ public class InMemoryLogRepositoryTests
         logsResult[0].Should().BeSameAs(logs[0]);
         logsResult[1].Should().BeSameAs(logs[1]);
     }
+
+    [Fact]
+    public async Task When_Append_Given_DuplicateEntriesWithSameTerm_Then_DoesNotTruncateSuffix()
+    {
+        // arrange
+        var logs = new LogEntry[]
+        {
+            new(1, 1, _fixture.Create<byte[]>()),
+            new(2, 1, _fixture.Create<byte[]>()),
+            new(3, 1, _fixture.Create<byte[]>())
+        };
+        await _subject.Append(logs);
+
+        // act
+        await _subject.Append(new[] { logs[2] });
+
+        // assert
+        _subject.LastIndex.Index.Should().Be(3);
+        var result = await _subject.GetLogsAtIndex(1, 3);
+        result.Should().Equal(logs);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task When_Append_Given_ConflictAtExistingIndex_Then_OnlyUncommittedSuffixCanBeReplaced(bool conflictIsCommitted)
+    {
+        // arrange
+        await _subject.Append(new[]
+        {
+            new LogEntry(1, 1, _fixture.Create<byte[]>()),
+            new LogEntry(2, 1, _fixture.Create<byte[]>()),
+            new LogEntry(3, 1, _fixture.Create<byte[]>())
+        });
+        await _subject.Commit(conflictIsCommitted ? 2 : 1);
+
+        var replacement = new LogEntry(2, 2, _fixture.Create<byte[]>());
+
+        // act
+        var act = () => _subject.Append(new[] { replacement });
+
+        // assert
+        if (conflictIsCommitted)
+        {
+            await act.Should().ThrowAsync<InvalidOperationException>();
+            _subject.LastIndex.Index.Should().Be(3);
+            _subject.LastIndex.Term.Should().Be(1);
+            _subject.CommitedIndex.Should().Be(2);
+        }
+        else
+        {
+            await act.Should().NotThrowAsync();
+            _subject.LastIndex.Index.Should().Be(2);
+            _subject.LastIndex.Term.Should().Be(2);
+            var result = await _subject.GetLogsAtIndex(1, 2);
+            result[1].Should().Be(replacement);
+        }
+    }
 }

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderMajorityTests.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderMajorityTests.cs
@@ -77,7 +77,7 @@ public class RaftLeaderMajorityTests : AbstractRaftIntegrationTest, IAsyncLifeti
 
         _logSerializerMock.SetupSerDes(command, commandPayload);
         _stateMachineMock
-            .Setup(x => x.Apply(command, 1))
+            .Setup(x => x.Apply(command, 2))
             .ReturnsAsync(commandResult);
 
         // node1 (index 0) replicates successfully; node2 (index 1) never advances past index 0
@@ -114,7 +114,7 @@ public class RaftLeaderMajorityTests : AbstractRaftIntegrationTest, IAsyncLifeti
 
         // assert: result returned (state machine applied), meaning commit happened with just 1 follower
         result.Should().Be(commandResult);
-        _stateMachineMock.Verify(x => x.Apply(command, 1), Times.Once);
+        _stateMachineMock.Verify(x => x.Apply(command, 2), Times.Once);
     }
 
     /// <summary>
@@ -195,6 +195,59 @@ public class RaftLeaderMajorityTests : AbstractRaftIntegrationTest, IAsyncLifeti
         // assert
         _logRepositoryMock.Object.CommitedIndex.Should().Be(1);
         _stateMachineMock.Verify(x => x.Apply(command, 1), Times.Once);
+    }
+
+    [Fact]
+    public async Task Given_FollowerBehindCompactedLog_When_LeaderReplicates_Then_InstallsSnapshot()
+    {
+        // arrange
+        var leaderTerm = 2;
+        var snapshot = new byte[] { 1, 2, 3 };
+
+        await _logRepositoryMock.Object.Append(new[]
+        {
+            new LogEntry(1, leaderTerm, Array.Empty<byte>()),
+            new LogEntry(2, leaderTerm, new byte[] { 10 }),
+            new LogEntry(3, leaderTerm, new byte[] { 11 })
+        });
+        await _logRepositoryMock.Object.Commit(3);
+        await _logRepositoryMock.Object.EraseBefore(3);
+
+        _stateMachineMock.Setup(x => x.Snapshot()).ReturnsAsync(snapshot);
+        _messageSenderMock
+            .Setup(x => x.SendRequest(It.IsAny<InstallSnapshotRequest>(), It.IsAny<IAddress>(), It.IsAny<TimeSpan?>()))
+            .ReturnsAsync((IRequest<InstallSnapshotResponse> r, IAddress _, TimeSpan? __) =>
+                new InstallSnapshotResponse((RaftMessage)r) { Term = leaderTerm, Success = true });
+
+        var subject = CreateLeaderStateProxy(leaderTerm);
+        subject.ReplicationStateByNode[_otherMembers[0].Node.Id] = new FollowerReplicatonState
+        {
+            NextIndex = 2,
+            MatchIndex = 1
+        };
+        subject.ReplicationStateByNode[_otherMembers[1].Node.Id] = new FollowerReplicatonState
+        {
+            NextIndex = 4,
+            MatchIndex = 3,
+            LastAppendRequest = DateTimeOffset.UtcNow.AddDays(1)
+        };
+
+        // act
+        await subject.OnLoopRunProxy();
+
+        // assert
+        _messageSenderMock.Verify(x => x.SendRequest(
+            It.Is<InstallSnapshotRequest>(r =>
+                r.Term == leaderTerm
+                && r.LastIncludedIndex == 2
+                && r.LastIncludedTerm == leaderTerm
+                && r.Offset == 0
+                && r.Done
+                && r.Data != null
+                && r.Data.SequenceEqual(snapshot)),
+            _otherMembers[0].Node.Address,
+            _options.LeaderPingInterval),
+            Times.Once);
     }
 
     private RaftLeaderStateProxy CreateLeaderStateProxy(int term)

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderMajorityTests.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderMajorityTests.cs
@@ -1,5 +1,8 @@
-namespace SlimCluster.Consensus.Raft.Test;
+﻿namespace SlimCluster.Consensus.Raft.Test;
 
+using SlimCluster.Consensus.Raft.Logs;
+using SlimCluster.Membership;
+using SlimCluster.Serialization;
 using SlimCluster.Transport;
 
 /// <summary>
@@ -38,6 +41,26 @@ public class RaftLeaderMajorityTests : AbstractRaftIntegrationTest, IAsyncLifeti
 
     public Task InitializeAsync() => Task.CompletedTask;
     public Task DisposeAsync() => _subject.Stop();
+
+    private sealed class RaftLeaderStateProxy : RaftLeaderState
+    {
+        public RaftLeaderStateProxy(
+            ILogger<RaftLeaderState> logger,
+            int term,
+            RaftConsensusOptions options,
+            IClusterMembership clusterMembership,
+            IMessageSender messageSender,
+            ILogRepository logRepository,
+            IStateMachine stateMachine,
+            ISerializer logSerializer,
+            ITime time,
+            OnNewerTermDiscovered onNewerTermDiscovered)
+            : base(logger, term, options, clusterMembership, messageSender, logRepository, stateMachine, logSerializer, time, onNewerTermDiscovered)
+        {
+        }
+
+        public Task<bool> OnLoopRunProxy() => OnLoopRun(default);
+    }
 
     /// <summary>
     /// In a 3-node cluster the leader should commit once ONE follower replicates
@@ -125,5 +148,85 @@ public class RaftLeaderMajorityTests : AbstractRaftIntegrationTest, IAsyncLifeti
 
         // assert: state machine was never applied
         _stateMachineMock.Verify(x => x.Apply(It.IsAny<object>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Given_MajorityReplicatedEntryFromOlderTerm_When_LeaderAppliesLogs_Then_EntryNotCommitted()
+    {
+        // arrange
+        var leaderTerm = 2;
+        var previousTerm = 1;
+        var command = new object();
+        var commandPayload = new byte[] { 11 };
+
+        _logSerializerMock.SetupSerDes(command, commandPayload);
+        await _logRepositoryMock.Object.Append(previousTerm, commandPayload);
+
+        var subject = CreateLeaderStateProxy(leaderTerm);
+        PreventReplicationRequests(subject, matchIndexForFirstFollower: 1, matchIndexForSecondFollower: 0);
+
+        // act
+        await subject.OnLoopRunProxy();
+
+        // assert
+        _logRepositoryMock.Object.CommitedIndex.Should().Be(0);
+        _stateMachineMock.Verify(x => x.Apply(It.IsAny<object>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Given_MajorityReplicatedEntryFromCurrentTerm_When_LeaderAppliesLogs_Then_EntryCommitted()
+    {
+        // arrange
+        var leaderTerm = 2;
+        var command = new object();
+        var commandPayload = new byte[] { 12 };
+        var commandResult = new object();
+
+        _logSerializerMock.SetupSerDes(command, commandPayload);
+        _stateMachineMock.Setup(x => x.Apply(command, 1)).ReturnsAsync(commandResult);
+        await _logRepositoryMock.Object.Append(leaderTerm, commandPayload);
+
+        var subject = CreateLeaderStateProxy(leaderTerm);
+        PreventReplicationRequests(subject, matchIndexForFirstFollower: 1, matchIndexForSecondFollower: 0);
+
+        // act
+        await subject.OnLoopRunProxy();
+
+        // assert
+        _logRepositoryMock.Object.CommitedIndex.Should().Be(1);
+        _stateMachineMock.Verify(x => x.Apply(command, 1), Times.Once);
+    }
+
+    private RaftLeaderStateProxy CreateLeaderStateProxy(int term)
+    {
+        return new RaftLeaderStateProxy(
+            NullLogger<RaftLeaderState>.Instance,
+            term,
+            _options,
+            _clusterMembershipMock.Object,
+            _messageSenderMock.Object,
+            _logRepositoryMock.Object,
+            _stateMachineMock.Object,
+            _logSerializerMock.Object,
+            new Time(),
+            _onNewerTermDiscovered.Object);
+    }
+
+    private void PreventReplicationRequests(RaftLeaderState subject, int matchIndexForFirstFollower, int matchIndexForSecondFollower)
+    {
+        var recentlySent = DateTimeOffset.UtcNow.AddDays(1);
+
+        subject.ReplicationStateByNode[_otherMembers[0].Node.Id] = new FollowerReplicatonState
+        {
+            NextIndex = 2,
+            MatchIndex = matchIndexForFirstFollower,
+            LastAppendRequest = recentlySent
+        };
+        subject.ReplicationStateByNode[_otherMembers[1].Node.Id] = new FollowerReplicatonState
+        {
+            NextIndex = 2,
+            MatchIndex = matchIndexForSecondFollower,
+            LastAppendRequest = recentlySent
+        };
     }
 }

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderStateTests.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/RaftLeaderStateTests.cs
@@ -41,12 +41,12 @@ public class RaftLeaderStateTests : AbstractRaftIntegrationTest, IAsyncLifetime
         var command = _fixture.Create<object>();
         var commandPayload = _fixture.Create<byte[]>();
         var commandResult = _fixture.Create<object>();
-        var commandIndex = 1;
+        var commandIndex = 2;
 
         _logSerializerMock.SetupSerDes(command, commandPayload);
 
         _stateMachineMock
-            .Setup(x => x.Apply(command, 1))
+            .Setup(x => x.Apply(command, commandIndex))
             .ReturnsAsync(commandResult);
 
         var otherNodeReplicatedIndex = _otherMembers.ToDictionary(x => x.Node.Address, x => 0);
@@ -81,25 +81,35 @@ public class RaftLeaderStateTests : AbstractRaftIntegrationTest, IAsyncLifetime
         await Task.Delay(TimeSpan.FromSeconds(1));
 
         _logRepositoryMock
+            .Verify(x => x.Append(_term, Array.Empty<byte>()), Times.Once);
+
+        _logRepositoryMock
             .Verify(x => x.Append(_term, commandPayload), Times.Once);
 
         _messageSenderMock
             .Verify(x => x.SendRequest(
-                It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 0 && r.PrevLogTerm == 0 && r.Entries == null),
+                It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 0 && r.PrevLogTerm == 0 && r.Entries != null && r.Entries.Count == 1 && r.Entries.First().Entry.Length == 0),
                 It.IsAny<IAddress>(),
                 _options.LeaderPingInterval),
                 Times.AtLeast(_otherMembers.Count));
 
         _messageSenderMock
             .Verify(x => x.SendRequest(
-                It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 0 && r.PrevLogTerm == 0 && r.Entries != null && r.Entries.Count == 1 && r.Entries.First().Entry == commandPayload),
+                It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 1 && r.PrevLogTerm == _term && r.Entries != null && r.Entries.Count == 1 && r.Entries.First().Entry == commandPayload),
                 It.IsAny<IAddress>(),
                 _options.LeaderPingInterval),
                 Times.Exactly(_otherMembers.Count));
 
         _messageSenderMock
             .Verify(x => x.SendRequest(
-                It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 1 && r.PrevLogTerm == 1 && r.Entries == null),
+                It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 1 && r.PrevLogTerm == _term && r.Entries == null),
+                It.IsAny<IAddress>(),
+                _options.LeaderPingInterval),
+                Times.AtLeast(_otherMembers.Count));
+
+        _messageSenderMock
+            .Verify(x => x.SendRequest(
+                It.Is<AppendEntriesRequest>(r => r.PrevLogIndex == 2 && r.PrevLogTerm == _term && r.Entries == null),
                 It.IsAny<IAddress>(),
                 _options.LeaderPingInterval),
                 Times.AtLeast(_otherMembers.Count));

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/RaftNodeTests.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/RaftNodeTests.cs
@@ -506,4 +506,33 @@ public class RaftNodeTests : AbstractRaftIntegrationTest, IAsyncLifetime
         // assert: stays follower, does not become candidate
         _subject.Status.Should().Be(RaftNodeStatus.Follower);
     }
+
+    [Fact]
+    public async Task Given_Follower_When_RequestVoteGranted_Then_ElectionTimerResets_And_StaysFollower()
+    {
+        // arrange
+        await _subject.OnLoopRunProxy(); // become follower
+        _logRepositoryMock.SetupGet(x => x.LastIndex).Returns(new LogIndex(0, 0));
+
+        var candidate = _otherMembers[0].Node;
+        var term = _subject.CurrentTerm + 1;
+
+        _now = _now.Add(_options.LeaderTimeout).AddSeconds(1);
+        await _subject.OnMessageArrived(
+            new RequestVoteRequest { CandidateId = candidate.Id, Term = term, LastLogIndex = 0, LastLogTerm = 0 },
+            candidate.Address);
+
+        // act
+        await _subject.OnLoopRunProxy();
+
+        // assert
+        _subject.Status.Should().Be(RaftNodeStatus.Follower);
+        _subject.CurrentTerm.Should().Be(term);
+        _messageSenderMock.Verify(
+            x => x.SendMessage(It.Is<RequestVoteResponse>(r => r.VoteGranted), candidate.Address),
+            Times.Once);
+        _messageSenderMock.Verify(
+            x => x.SendMessage(It.IsAny<RequestVoteRequest>(), It.IsAny<IAddress>()),
+            Times.Never);
+    }
 }

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/SlimCluster.Consensus.Raft.Test.csproj
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/SlimCluster.Consensus.Raft.Test.csproj
@@ -31,4 +31,8 @@
     <ProjectReference Include="..\..\SlimCluster.Consensus.Raft\SlimCluster.Consensus.Raft.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/xunit.runner.json
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true,
+  "longRunningTestSeconds": 30,
+  "methodDisplay": "classAndMethod"
+}


### PR DESCRIPTION
## Summary
- enforce Raft current-term commit advancement, append a leader no-op entry, and use current membership size for quorum calculations
- harden follower log reconciliation so committed entries cannot be overwritten and duplicate same-term entries do not truncate suffixes
- restore Raft nodes into a valid follower runtime state, reset follower election timeout after granting votes, and persist term/vote transitions
- wire follower and leader snapshot install paths with snapshot ids, chunk validation, size limits, and compacted-log metadata
- evolve the sample counter state machine with JSON snapshot/install support instead of snapshot stubs
- make task loop shutdown cancellation-aware and add long-running test diagnostics

## Verification
- dotnet build src\SlimCluster.Consensus.Raft\SlimCluster.Consensus.Raft.csproj --no-restore -v minimal -m:1 -nodeReuse:false
- dotnet build src\Samples\SlimCluster.Samples.Service\SlimCluster.Samples.Service.csproj --no-restore -v minimal -m:1 -nodeReuse:false
- dotnet test src\Tests\SlimCluster.Consensus.Raft.Test\SlimCluster.Consensus.Raft.Test.csproj --no-restore -v minimal --blame-hang-timeout 30s -- RunConfiguration.TestSessionTimeout=60000