### PR TITLE
Migrate tests to AwesomeAssertions

### DIFF
--- a/src/Tests/SlimCluster.Consensus.Raft.Test/SlimCluster.Consensus.Raft.Test.csproj
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/SlimCluster.Consensus.Raft.Test.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/Tests/SlimCluster.Consensus.Raft.Test/Usings.cs
+++ b/src/Tests/SlimCluster.Consensus.Raft.Test/Usings.cs
@@ -1,4 +1,4 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 
 global using Microsoft.Extensions.Logging.Abstractions;
 global using Microsoft.Extensions.Logging;

--- a/src/Tests/SlimCluster.Membership.Swim.Test/SlimCluster.Membership.Swim.Test.csproj
+++ b/src/Tests/SlimCluster.Membership.Swim.Test/SlimCluster.Membership.Swim.Test.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/Tests/SlimCluster.Membership.Swim.Test/Usings.cs
+++ b/src/Tests/SlimCluster.Membership.Swim.Test/Usings.cs
@@ -3,5 +3,5 @@ global using Xunit.Abstractions;
 global using Microsoft.Extensions.Logging.Abstractions;
 global using Moq;
 global using System.Net;
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using SlimCluster.Common.Test;

--- a/src/Tests/SlimCluster.Persistence.LocalFile.Test/SlimCluster.Persistence.LocalFile.Test.csproj
+++ b/src/Tests/SlimCluster.Persistence.LocalFile.Test/SlimCluster.Persistence.LocalFile.Test.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/src/Tests/SlimCluster.Persistence.LocalFile.Test/Usings.cs
+++ b/src/Tests/SlimCluster.Persistence.LocalFile.Test/Usings.cs
@@ -1,6 +1,6 @@
 global using AutoFixture;
 
-global using FluentAssertions;
+global using AwesomeAssertions;
 
 global using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tests/SlimCluster.Transport.Ip.Tests/SlimCluster.Transport.Ip.Test.csproj
+++ b/src/Tests/SlimCluster.Transport.Ip.Tests/SlimCluster.Transport.Ip.Test.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/Tests/SlimCluster.Transport.Ip.Tests/Usings.cs
+++ b/src/Tests/SlimCluster.Transport.Ip.Tests/Usings.cs
@@ -1,6 +1,6 @@
 global using System.Net;
 
-global using FluentAssertions;
+global using AwesomeAssertions;
 
 global using Microsoft.Extensions.Logging.Abstractions;
 global using Microsoft.Extensions.Options;


### PR DESCRIPTION
## Summary
- Replace FluentAssertions package references with AwesomeAssertions 9.4.0 in test projects
- Update global assertion usings to AwesomeAssertions

## Testing
- dotnet test src\SlimCluster.slnx --no-restore -v minimal -m:1